### PR TITLE
FIX: resampling errors during testing

### DIFF
--- a/expyfun/experiment_controller.py
+++ b/expyfun/experiment_controller.py
@@ -827,7 +827,7 @@ class ExperimentController(object):
         # check shape
         if samples.ndim == 2 and min(samples.shape) > 2:
             raise ValueError('Sound data has more than two channels.')
-        elif len(samples.shape) == 2 and samples.shape[0] == 2:
+        elif len(samples.shape) == 2 and samples.shape[0] <= 2:
             samples = samples.T
 
         # resample if needed

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -9,7 +9,8 @@ from expyfun.utils import _TempDir, interactive_test, tdt_test
 temp_dir = _TempDir()
 std_args = ['test']  # experiment name
 std_kwargs = dict(output_dir=temp_dir, full_screen=False, window_size=(1, 1),
-                  participant='foo', session='01', stim_db=0.0, noise_db=0.0)
+                  participant='foo', session='01', stim_db=0.0, noise_db=0.0,
+                  stim_fs=48000)
 
 
 def dummy_print(string):


### PR DESCRIPTION
the bug turned out to be in my code, and the fix was embarassingly small, @Eric89GXL. Also added `stim_fs` to `**stdkwargs` to make sure we're testing the resampling code during nosetests.
