### PR TITLE
FIX: bug in format_pval

### DIFF
--- a/expyfun/analyze/_viz.py
+++ b/expyfun/analyze/_viz.py
@@ -35,6 +35,7 @@ def format_pval(pval, latex=True, scheme='default'):
         A string or array of strings of formatted p-values. If a list output is
         preferred, users may call ``.tolist()`` on the output of the function.
     """
+    single_value = False
     if np.array(pval).shape == ():
         single_value = True
     pval = np.atleast_1d(np.asanyarray(pval))

--- a/expyfun/analyze/tests/test_viz.py
+++ b/expyfun/analyze/tests/test_viz.py
@@ -63,6 +63,8 @@ def test_format_pval():
     """Test p-value formatting
     """
     foo = ea.format_pval(1e-10, latex=False)
-    bar = ea.format_pval(1e-10, latex=True, scheme='ross')
+    bar = ea.format_pval(1e-10, scheme='ross')
+    baz = ea.format_pval([0.2, 0.02])
     assert_equal(foo, 'p < 10^-9')
     assert_equal(bar, '$p < 10^{{-9}}$')
+    assert_equal(baz[0], '$n.s.$')


### PR DESCRIPTION
Fixes bug in `expyfun.analyze.format_pval()` when passing in arrays or lists of pvals instead of singletons.  Should be a no-brainer, @Eric89GXL @rkmaddox
