### PR TITLE
Fixed docstring for screen_text

### DIFF
--- a/expyfun/__init__.py
+++ b/expyfun/__init__.py
@@ -4,7 +4,7 @@
 __version__ = '2.0.0.git'
 
 # have to import verbose first since it's needed by many things
-from ._utils import (set_log_level, set_log_file, set_config,
+from ._utils import (set_log_level, set_log_file, set_config, check_units,
                      get_config, get_config_path, fetch_data_file)
 from ._utils import verbose_dec as verbose
 from ._experiment_controller import (ExperimentController, wait_secs,

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -16,7 +16,7 @@ from pyglet import gl
 
 from ._utils import (get_config, verbose_dec, _check_pyglet_version, wait_secs,
                      running_rms, _sanitize, logger, ZeroClock, date_str,
-                     _check_units, set_log_file, flush_logger,
+                     check_units, set_log_file, flush_logger,
                      string_types, input)
 from ._tdt_controller import TDTController
 from ._trigger_controllers import ParallelTrigger
@@ -391,11 +391,17 @@ class ExperimentController(object):
             x, y position of the text. In the default units (-1 to 1, with
             positive going up and right) the default is dead center (0, 0).
         units : str
-            Units for ``pos``.
+            Units for ``pos``. See ``check_units`` for options.
+        color : matplotlib color
+            The text color.
+        font_name : str
+            The name of the font to use.
+        font_size : float
+            The font size (in points) to use.
         wrap : bool
             Whether or not the text will wrap to fit in screen, appropriate
             for multi-line text. Inappropriate for text requiring
-            precise positioning.
+            precise positioning or centering.
 
         Returns
         -------
@@ -589,8 +595,8 @@ class ExperimentController(object):
 
     def _convert_units(self, verts, fro, to):
         """Convert between different screen units"""
-        _check_units(to)
-        _check_units(fro)
+        check_units(to)
+        check_units(fro)
         verts = np.array(np.atleast_2d(verts), dtype=float)
         if verts.shape[0] != 2:
             raise RuntimeError('verts must have 2 rows')
@@ -924,14 +930,14 @@ class ExperimentController(object):
         Parameters
         ----------
         units : str
-            Units to return.
+            Units to return. See ``check_units`` for options.
 
         Returns
         -------
         position : ndarray
             The mouse position.
         """
-        _check_units(units)
+        check_units(units)
         pos = np.array(self._mouse_handler.pos)
         pos = self._convert_units(pos[:, np.newaxis], 'norm', units)[:, 0]
         return pos

--- a/expyfun/_eyelink_controller.py
+++ b/expyfun/_eyelink_controller.py
@@ -438,7 +438,7 @@ class EyelinkController(object):
         check_interval : float
             Time to use between position checks (seconds).
         units : str
-            Units for `fix_pos`.
+            Units for `fix_pos`. See ``check_units`` for options.
 
         Returns
         -------
@@ -483,7 +483,7 @@ class EyelinkController(object):
         vert : float
             Vertical distance (up and down, each) to use.
         units : str
-            Units to use.
+            Units to use. See ``check_units`` for options.
         """
         allowed_types = ['HV5']
         if ctype not in allowed_types:

--- a/expyfun/_utils.py
+++ b/expyfun/_utils.py
@@ -228,8 +228,14 @@ class _TempDir(str):
             rmtree(self._path, ignore_errors=True)
 
 
-def _check_units(units):
-    """Helper to make sure user passed in valid units type"""
+def check_units(units):
+    """Ensure user passed valid units type
+
+    Parameters
+    ----------
+    units : str
+        Must be ``'norm'``, ``'deg'``, or ``'pix'``.
+    """
     good_units = ['norm', 'pix', 'deg']
     if units not in good_units:
         raise ValueError('"units" must be one of {}, not {}'

--- a/expyfun/visual/_visual.py
+++ b/expyfun/visual/_visual.py
@@ -12,7 +12,7 @@ import pyglet
 from matplotlib.colors import colorConverter
 from pyglet import gl
 
-from .._utils import _check_units, string_types
+from .._utils import check_units, string_types
 
 
 def _convert_color(color):
@@ -55,12 +55,12 @@ class Text(object):
         the screen width, useful for instructions. None will automatically
         allocate sufficient space, but not that this disables text wrapping.
     anchor_x : str
-        Horizontal text anchor (e.g., `'center'`).
+        Horizontal text anchor (e.g., ``'center'``).
     anchor_y : str
-        Vertical text anchor (e.g., `'center'`).
+        Vertical text anchor (e.g., ``'center'``).
     units : str
         Units to use. These will apply to all spatial aspects of the drawing.
-        shape e.g. size, position.
+        shape e.g. size, position. See ``check_units`` for options.
     wrap : bool
         Whether or not the text will wrap to fit in screen, appropriate for
         multiline text. Inappropriate for text requiring precise positioning.
@@ -179,7 +179,7 @@ class Line(_Triangular):
         2 x N set of X, Y coordinates.
     units : str
         Units to use. These will apply to all spatial aspects of the drawing.
-        shape e.g. size, position.
+        shape e.g. size, position. See ``check_units`` for options.
     line_color : matplotlib Color
         Color of the line.
     line_width : float
@@ -209,7 +209,7 @@ class Line(_Triangular):
         coords : array-like
             2 x N set of X, Y coordinates.
         """
-        _check_units(units)
+        check_units(units)
         coords = np.array(coords, dtype=float)
         if coords.ndim == 1:
             coords = coords[:, np.newaxis]
@@ -232,7 +232,7 @@ class Rectangle(_Triangular):
         4-element array-like with X, Y center and width, height.
     units : str
         Units to use. These will apply to all spatial aspects of the drawing.
-        shape e.g. size, position.
+        shape e.g. size, position. See ``check_units`` for options.
     fill_color : matplotlib Color | None
         Color to fill with. None is transparent.
     line_color : matplotlib Color | None
@@ -260,9 +260,9 @@ class Rectangle(_Triangular):
         pos : array-like
             X, Y, width, height of the rectangle.
         units : str
-            Units to use.
+            Units to use. See ``check_units`` for options.
         """
-        _check_units(units)
+        check_units(units)
         # do this in normalized units, then convert
         pos = np.array(pos)
         if not (pos.ndim == 1 and pos.size == 4):
@@ -295,7 +295,7 @@ class Circle(_Triangular):
         2-element array-like with X, Y center positions.
     units : str
         Units to use. These will apply to all spatial aspects of the drawing.
-        shape e.g. size, position.
+        shape e.g. size, position. See ``check_units`` for options.
     n_edges : int
         Number of edges to use (must be >= 4) to approximate a circle.
     fill_color : matplotlib Color | None
@@ -342,9 +342,9 @@ class Circle(_Triangular):
             X- and Y-direction extents (radii) of the circle / ellipse.
             A single value (float) will be replicated for both directions.
         units : str
-            Units to use.
+            Units to use. See ``check_units`` for options.
         """
-        _check_units(units)
+        check_units(units)
         radius = np.atleast_1d(radius).astype(float)
         if radius.ndim != 1 or radius.size > 2:
             raise ValueError('radius must be a 1- or 2-element '
@@ -367,9 +367,9 @@ class Circle(_Triangular):
         pos : array-like
             X, Y center of the circle.
         units : str
-            Units to use.
+            Units to use. See ``check_units`` for options.
         """
-        _check_units(units)
+        check_units(units)
         pos = np.array(pos, dtype=float)
         if not (pos.ndim == 1 and pos.size == 2):
             raise ValueError('pos must be a 2-element array-like vector')
@@ -405,6 +405,7 @@ class ConcentricCircles(object):
         2-element array-like with the X, Y center position.
     units : str
         Units to use. These will apply to all spatial aspects of the drawing.
+        See ``check_units`` for options.
     colors : list or tuple of matplotlib Colors
         Color to fill each circle with.
 
@@ -437,7 +438,7 @@ class ConcentricCircles(object):
         pos : array-like
             X, Y center of the circle.
         units : str
-            Units to use.
+            Units to use. See ``check_units`` for options.
         """
         for circle in self._circles:
             circle.set_pos(pos, units)
@@ -452,7 +453,7 @@ class ConcentricCircles(object):
         idx : int
             Index of the circle.
         units : str
-            Units to use.
+            Units to use. See ``check_units`` for options.
         """
         self._circles[idx].set_radius(radius, units)
 
@@ -465,7 +466,7 @@ class ConcentricCircles(object):
             List of radii to assign to the circles. Must contain the same
             number of radii as the number of circles.
         units : str
-            Units to use.
+            Units to use. See ``check_units`` for options.
         """
         radii = np.array(radii, float)
         if radii.ndim != 1 or radii.size != len(self):
@@ -484,7 +485,7 @@ class ConcentricCircles(object):
         idx : int
             Index of the circle.
         units : str
-            Units to use.
+            Units to use. See ``check_units`` for options.
         """
         self._circles[idx].set_fill_color(color)
 
@@ -556,7 +557,7 @@ class RawImage(object):
         The scale factor. 1 is native size (pixel-to-pixel), 2 is twice as
         large, etc.
     units : str
-        Units to use for the position.
+        Units to use for the position. See ``check_units`` for options.
 
     Returns
     -------
@@ -609,7 +610,7 @@ class RawImage(object):
         pos : array-like
             2-element array-like with X, Y (center) arguments.
         units : str
-            Units to use.
+            Units to use. See ``check_units`` for options.
         """
         pos = np.array(pos, float)
         if pos.ndim != 1 or pos.size != 2:
@@ -640,7 +641,7 @@ class RawImage(object):
         pos : array-like
             2-element array-like with X, Y (center) arguments.
         units : str
-            Units to use.
+            Units to use. See ``check_units`` for options.
         """
         scale = float(scale)
         self._scale = scale


### PR DESCRIPTION
Had arguments listed in doc string for `h_align` and `v_align`. Shouldn't.
