### PR TITLE
ENH: expose _Triangular

### DIFF
--- a/expyfun/visual/__init__.py
+++ b/expyfun/visual/__init__.py
@@ -1,2 +1,3 @@
 from ._visual import (Text, Line, Triangle, Rectangle, Circle, RawImage,
-                      Diamond, ConcentricCircles, FixationDot, _convert_color)
+                      Diamond, ConcentricCircles, FixationDot, _convert_color,
+                      _Triangular)


### PR DESCRIPTION
Will allow power users to define their own visual objects based on the `_Triangular` class that may be too specialized to include in the `visual` module.
