### PR TITLE
MRG: add circle

### DIFF
--- a/examples/experiments/sync_test.py
+++ b/examples/experiments/sync_test.py
@@ -2,9 +2,7 @@
 =============
 A-V sync test
 =============
-
 This example tests synchronization between the screen and the audio playback.
-
 NOTE: On Linux (w/NVIDIA), XFCE has been observed to give consistent timings,
 whereas Compiz WMs did not (doubled timings).
 """
@@ -16,6 +14,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from expyfun import ExperimentController
+from expyfun.visual import Circle
 import expyfun.analyze as ea
 
 print(__doc__)
@@ -28,13 +27,16 @@ with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
     ec.load_buffer(np.r_[0.1, np.zeros(99)])  # RMS == 0.01
     pressed = None
     screenshot = None
+    # Make a circle so that the photodiode can be centered on the screen
+    circle = Circle(ec, 1, units='deg', fill_color='k', line_color='w')
     while pressed != '8':  # enable a clean quit if required
         ec.set_background_color('white')
         t1 = ec.start_stimulus(start_of_trial=False)  # skip checks
         ec.set_background_color('black')
         t2 = ec.flip()
         diff = round(1000 * (t2 - t1), 2)
-        ec.screen_text('IFI (ms): {}'.format(diff), wrap=False)
+        ec.screen_text('IFI (ms): {}'.format(diff), wrap=True)
+        circle.draw()
         screenshot = ec.screenshot() if screenshot is None else screenshot
         ec.flip()
         pressed = ec.wait_one_press(0.5)[0]

--- a/expyfun/analyze/tests/test_viz.py
+++ b/expyfun/analyze/tests/test_viz.py
@@ -79,7 +79,7 @@ def test_barplot():
                groups=[[0, 1, 2], [3, 4]], bracket_group_lines=True,
                brackets=[(0, 1), (1, 2), (3, 4), ([0, 1, 2], [3, 4])],
                bracket_text=['foo', 'bar', 'baz', 'snafu'])
-    extns = ['eps', 'pdf', 'png', 'raw', 'svg']  # jpg, tif not supported
+    extns = ['pdf']  # jpg, tif not supported; 'png', 'raw', 'svg' not tested
     for ext in extns:
         fname = op.join(temp_dir, 'temp.' + ext)
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
Moves text to side and makes an empty white circle in the middle so that the photodiode timing can be referenced exactly to the center of the screen.