### PR TITLE
MRG: New video implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
     # install AVbin
     - curl https://github.com/downloads/AVbin/AVbin/install-avbin-linux-x86-64-v10 -o avbin.sh
     - chmod +x avbin.sh
-    - yes | sudo ./avbin.sh
+    - sudo sh -c "yes | ./avbin.sh"
     # Only install these deps if necessary (slow on Py3k)
     - travis_retry pip install -q nose-timer flake8;
     - travis_retry pip install -q pyglet mne six;  # mne is a dependency now that resample is taken from it

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
     # install AVbin
     - curl https://github.com/downloads/AVbin/AVbin/install-avbin-linux-x86-64-v10 -o avbin.sh
     - chmod +x avbin.sh
-    - sudo sh -c "yes | ./avbin.sh"
+    - sudo bash -c "yes | ./avbin.sh"
     # Only install these deps if necessary (slow on Py3k)
     - travis_retry pip install -q nose-timer flake8;
     - travis_retry pip install -q pyglet mne six;  # mne is a dependency now that resample is taken from it

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,15 @@ before_install:
         conda install --yes scipy matplotlib nose coverage setuptools;
         travis_retry pip install -q coveralls;
       fi;
+    # install a newer version of wget (avoid SSL errors)
+    - mkdir wget
+    - wget http://ftp.gnu.org/gnu/wget/wget-1.17.tar.xz -O wget.xz
+    - tar xf wget.xz -C ./wget --strip-components=1
+    - cd wget && ./configure && make
+    - sudo make install
+    - cd
     # install AVbin
-    - wget --no-check-certificate https://github.com/downloads/AVbin/AVbin/install-avbin-linux-x86-64-v10 -O avbin.sh
+    - wget https://github.com/downloads/AVbin/AVbin/install-avbin-linux-x86-64-v10 -O avbin.sh
     - chmod +x avbin.sh
     - yes | sudo ./avbin.sh
     # Only install these deps if necessary (slow on Py3k)

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,9 @@ before_install:
     - wget https://github.com/downloads/AVbin/AVbin/install-avbin-linux-x86-64-v10 -O avbin.sh
     - chmod +x avbin.sh
     - yes | sudo ./avbin.sh
+    # fix for InsecurePlatformWarning in pip
+    - travis_retry pip install pyopenssl pyasn1
+    - travis_retry pip install --upgrade ndg-httpsclient
     # Only install these deps if necessary (slow on Py3k)
     - travis_retry pip install -q nose-timer flake8;
     - travis_retry pip install -q pyglet mne six;  # mne is a dependency now that resample is taken from it

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ before_install:
         travis_retry pip install -q coveralls;
       fi;
     # install AVbin
-    - curl https://github.com/downloads/AVbin/AVbin/install-avbin-linux-x86-64-v10 -o avbin.sh
+    - curl https://cloud.github.com/downloads/AVbin/AVbin/install-avbin-linux-x86-64-v10 -o avbin.sh
     - chmod +x avbin.sh
-    - sudo bash -c "yes | ./avbin.sh"
+    - yes | sudo tee /dev/null | ./avbin.sh
     # Only install these deps if necessary (slow on Py3k)
     - travis_retry pip install -q nose-timer flake8;
     - travis_retry pip install -q pyglet mne six;  # mne is a dependency now that resample is taken from it

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ before_install:
         conda install --yes scipy matplotlib nose coverage setuptools;
         travis_retry pip install -q coveralls;
       fi;
+    # install AVbin
+    - wget --no-check-certificate https://github.com/downloads/AVbin/AVbin/install-avbin-linux-x86-64-v10 -O avbin.sh
+    - chmod +x avbin.sh
+    - yes | sudo ./avbin.sh
     # Only install these deps if necessary (slow on Py3k)
     - travis_retry pip install -q nose-timer flake8;
     - travis_retry pip install -q pyglet mne six;  # mne is a dependency now that resample is taken from it
@@ -60,3 +64,4 @@ script:
 after_success:
     # Need to run from source dir to execute appropriate "git" commands
     - coveralls
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
+sudo: required
+dist: trusty
 language: python
 
 python:
     - "2.7"
 
 env:
-    - PYTHON=2.7 DEPS=full TEST=standard
-    - PYTHON=2.7 DEPS=minimal TEST=standard
+    - PYTHON=2.7.10 DEPS=full TEST=standard
+    - PYTHON=2.7.10 DEPS=minimal TEST=standard
     - PYTHON=3.4 DEPS=full TEST=standard _EXPYFUN_SILENT=true
     # The _EXPYFUN_SILENT is a workaround for a silly Py3/Travis bug
 
@@ -32,13 +34,6 @@ before_install:
         conda install --yes scipy matplotlib nose coverage setuptools;
         travis_retry pip install -q coveralls;
       fi;
-    # install a newer version of wget (avoid SSL errors)
-    - mkdir wget
-    - wget http://ftp.gnu.org/gnu/wget/wget-1.17.tar.xz -O wget.xz
-    - tar xf wget.xz -C ./wget --strip-components=1
-    - cd wget && ./configure && make
-    - sudo make install
-    - cd
     # install AVbin
     - wget https://github.com/downloads/AVbin/AVbin/install-avbin-linux-x86-64-v10 -O avbin.sh
     - chmod +x avbin.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
     # install AVbin
     - curl https://cloud.github.com/downloads/AVbin/AVbin/install-avbin-linux-x86-64-v10 -o avbin.sh
     - chmod +x avbin.sh
-    - yes | sudo tee /dev/null | ./avbin.sh
+    - sudo bash -c "yes | ./avbin.sh"
     # Only install these deps if necessary (slow on Py3k)
     - travis_retry pip install -q nose-timer flake8;
     - travis_retry pip install -q pyglet mne six;  # mne is a dependency now that resample is taken from it

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
-sudo: required
-dist: trusty
 language: python
 
 python:
     - "2.7"
 
 env:
-    - PYTHON=2.7.10 DEPS=full TEST=standard
-    - PYTHON=2.7.10 DEPS=minimal TEST=standard
+    - PYTHON=2.7 DEPS=full TEST=standard
+    - PYTHON=2.7 DEPS=minimal TEST=standard
     - PYTHON=3.4 DEPS=full TEST=standard _EXPYFUN_SILENT=true
     # The _EXPYFUN_SILENT is a workaround for a silly Py3/Travis bug
 
@@ -19,7 +17,7 @@ before_install:
     # Only use Pulseaudio on 2.7 because on Travis 3.4 causes some strange error...
     - SRC_DIR=${PWD}
     - travis_retry sudo apt-get update -qq
-    - if [ "${PYTHON}" == "2.7.10" ]; then
+    - if [ "${PYTHON}" == "2.7" ]; then
         travis_retry sudo apt-get install -qq -y pulseaudio python-nose python-coverage python-scipy python-matplotlib python-setuptools;
         dbus-launch pulseaudio --start;
         travis_retry sudo pip install -q coveralls;
@@ -35,18 +33,15 @@ before_install:
         travis_retry pip install -q coveralls;
       fi;
     # install AVbin
-    - wget https://github.com/downloads/AVbin/AVbin/install-avbin-linux-x86-64-v10 -O avbin.sh
+    - curl https://github.com/downloads/AVbin/AVbin/install-avbin-linux-x86-64-v10 -o avbin.sh
     - chmod +x avbin.sh
     - yes | sudo ./avbin.sh
-    # fix for InsecurePlatformWarning in pip
-    - travis_retry pip install pyopenssl pyasn1
-    - travis_retry pip install --upgrade ndg-httpsclient
     # Only install these deps if necessary (slow on Py3k)
     - travis_retry pip install -q nose-timer flake8;
     - travis_retry pip install -q pyglet mne six;  # mne is a dependency now that resample is taken from it
     # Full dependencies (pandas, mne-python, h5py, joblib)
     - if [ "${DEPS}" == "full" ]; then
-        if [ "${PYTHON}" == "2.7.10" ]; then
+        if [ "${PYTHON}" == "2.7" ]; then
           sudo apt-get install -qq -y python-pandas python-h5py python-joblib;
         else
           conda install --yes --quiet pandas h5py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
     # Only use Pulseaudio on 2.7 because on Travis 3.4 causes some strange error...
     - SRC_DIR=${PWD}
     - travis_retry sudo apt-get update -qq
-    - if [ "${PYTHON}" == "2.7" ]; then
+    - if [ "${PYTHON}" == "2.7.10" ]; then
         travis_retry sudo apt-get install -qq -y pulseaudio python-nose python-coverage python-scipy python-matplotlib python-setuptools;
         dbus-launch pulseaudio --start;
         travis_retry sudo pip install -q coveralls;
@@ -43,7 +43,7 @@ before_install:
     - travis_retry pip install -q pyglet mne six;  # mne is a dependency now that resample is taken from it
     # Full dependencies (pandas, mne-python, h5py, joblib)
     - if [ "${DEPS}" == "full" ]; then
-        if [ "${PYTHON}" == "2.7" ]; then
+        if [ "${PYTHON}" == "2.7.10" ]; then
           sudo apt-get install -qq -y python-pandas python-h5py python-joblib;
         else
           conda install --yes --quiet pandas h5py;

--- a/examples/stimuli/video_playback.py
+++ b/examples/stimuli/video_playback.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+======================
+Play sample video file
+======================
+
+This shows how to play a video file in expyfun.
+
+@author: drmccloy
+"""
+
+import numpy as np
+from expyfun import ExperimentController, fetch_data_file
+
+print(__doc__)
+
+
+movie_path = fetch_data_file('video/example-video.mp4')
+
+ec_args = dict(exp_name='movietest', window_size=(720, 480),
+               full_screen=False, participant='foo', session='foo',
+               version='dev', enable_video=True)
+
+with ExperimentController(**ec_args) as ec:
+    screen_period = 1. / ec.estimate_screen_fs()
+    all_presses = list()
+    ec.load_video(movie_path)
+    ec.screen_prompt('press 1 during video to toggle pause.', max_wait=1.)
+    ec.listen_presses()
+    t_zero = ec.video.play()
+    while not ec.video.finished:
+        if ec.video.playing:
+            fliptime = ec.flip()
+        else:  # to catch presses reliably, need delay between loop executions
+            ec.wait_secs(screen_period / 5)
+        presses = ec.get_presses(live_keys=[1], relative_to=t_zero)
+        ec.listen_presses()
+        if ec.video.playing and 3 < ec.video.time < 4.5:
+            ec.video.set_scale(ec.video.scale * 0.99)
+        if ec.video.playing and ec.video.time > 4.5:
+            ec.video.set_pos(ec.video.position + np.array((0.01, 0)))
+        if len(presses):
+            all_presses.extend(presses)
+            if ec.video.playing:
+                ec.screen_text('pause!')
+                ec.flip()
+                ec.video.pause()
+            else:
+                ec.screen_text('play!')
+                ec.video.play()
+    ec.delete_video()
+    preamble = 'press times:' if len(all_presses) else 'no presses'
+    msg = ', '.join(['{0:.3f}'.format(x[1]) for x in all_presses])
+    ec.flip()
+    ec.screen_prompt('\n'.join([preamble, msg]), max_wait=1.)

--- a/examples/stimuli/video_playback.py
+++ b/examples/stimuli/video_playback.py
@@ -25,6 +25,7 @@ with ExperimentController(**ec_args) as ec:
     screen_period = 1. / ec.estimate_screen_fs()
     all_presses = list()
     ec.load_video(movie_path)
+    ec.video.set_scale(fill=True)
     ec.screen_prompt('press 1 during video to toggle pause.', max_wait=1.)
     ec.listen_presses()
     t_zero = ec.video.play()

--- a/examples/stimuli/video_playback.py
+++ b/examples/stimuli/video_playback.py
@@ -25,7 +25,7 @@ with ExperimentController(**ec_args) as ec:
     screen_period = 1. / ec.estimate_screen_fs()
     all_presses = list()
     ec.load_video(movie_path)
-    ec.video.set_scale(fill=True)
+    ec.video.set_scale('fill')
     ec.screen_prompt('press 1 during video to toggle pause.', max_wait=1.)
     ec.listen_presses()
     t_zero = ec.video.play()
@@ -36,19 +36,19 @@ with ExperimentController(**ec_args) as ec:
             ec.wait_secs(screen_period / 5)
         presses = ec.get_presses(live_keys=[1], relative_to=t_zero)
         ec.listen_presses()
-        if ec.video.playing and 3 < ec.video.time < 4.5:
+        if ec.video.playing and 2 < ec.video.time < 4.5:
             ec.video.set_scale(ec.video.scale * 0.99)
         if ec.video.playing and ec.video.time > 4.5:
             ec.video.set_pos(ec.video.position + np.array((0.01, 0)))
         if len(presses):
             all_presses.extend(presses)
             if ec.video.playing:
-                ec.screen_text('pause!')
-                ec.flip()
                 ec.video.pause()
+                ec.screen_text('pause!', color='red', font_size=32, wrap=False)
+                ec.flip()
             else:
-                ec.screen_text('play!')
                 ec.video.play()
+                ec.screen_text('play!', color='red', font_size=64, wrap=False)
     ec.delete_video()
     preamble = 'press times:' if len(all_presses) else 'no presses'
     msg = ', '.join(['{0:.3f}'.format(x[1]) for x in all_presses])

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -440,7 +440,8 @@ class ExperimentController(object):
         scr_txt = Text(self, text, pos, color, font_name, font_size,
                        wrap=wrap, units=units, attr=attr)
         scr_txt.draw()
-        self.call_on_next_flip(self.write_data_line, 'screen_text', text)
+        self.call_on_next_flip(partial(self.write_data_line, 'screen_text',
+                                       text))
         return scr_txt
 
     def screen_prompt(self, text, max_wait=np.inf, min_wait=0, live_keys=None,
@@ -596,7 +597,7 @@ class ExperimentController(object):
                 fun()
         return stimulus_time
 
-    def call_on_next_flip(self, function, *args, **kwargs):
+    def call_on_next_flip(self, function):
         """Add a function to be executed on next flip only.
 
         Parameters
@@ -604,8 +605,6 @@ class ExperimentController(object):
         function : function | None
             The function to call. If ``None``, all the "on every flip"
             functions will be cleared.
-        *args, **kwargs : arguments and keyword arguments
-            Arguments to pass to the function when calling it.
 
         See Also
         --------
@@ -614,15 +613,16 @@ class ExperimentController(object):
         Notes
         -----
         See `flip_and_play` for order of operations. Can be called multiple
-        times to add multiple functions to the queue.
+        times to add multiple functions to the queue. If the function must be
+        called with arguments, use `functools.partial` before passing to
+        `call_on_next_flip`.
         """
         if function is not None:
-            function = partial(function, *args, **kwargs)
             self._on_next_flip.append(function)
         else:
             self._on_next_flip = []
 
-    def call_on_every_flip(self, function, *args, **kwargs):
+    def call_on_every_flip(self, function):
         """Add a function to be executed on every flip.
 
         Parameters
@@ -630,8 +630,6 @@ class ExperimentController(object):
         function : function | None
             The function to call. If ``None``, all the "on every flip"
             functions will be cleared.
-        *args, **kwargs : arguments and keyword arguments
-            Arguments to pass to the function when calling it.
 
         See Also
         --------
@@ -640,10 +638,11 @@ class ExperimentController(object):
         Notes
         -----
         See `flip_and_play` for order of operations. Can be called multiple
-        times to add multiple functions to the queue.
+        times to add multiple functions to the queue. If the function must be
+        called with arguments, use `functools.partial` before passing to
+        `call_on_every_flip`.
         """
         if function is not None:
-            function = partial(function, *args, **kwargs)
             self._on_every_flip.append(function)
         else:
             self._on_every_flip = []

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -26,7 +26,7 @@ from ._trigger_controllers import ParallelTrigger
 from ._sound_controllers import PygletSoundController, SoundPlayer
 from ._input_controllers import Keyboard, CedrusBox, Mouse
 from .stimuli._filter import resample
-from .visual import Text, Rectangle, _convert_color
+from .visual import Text, Rectangle, Video, _convert_color
 from ._git import assert_version
 
 
@@ -125,7 +125,7 @@ class ExperimentController(object):
                  full_screen=True, force_quit=None, participant=None,
                  monitor=None, trigger_controller=None, session=None,
                  verbose=None, check_rms='windowed', suppress_resamp=False,
-                 version=None):
+                 version=None, enable_video=False):
         # initialize some values
         self._stim_fs = stim_fs
         self._stim_rms = stim_rms
@@ -133,6 +133,8 @@ class ExperimentController(object):
         self._noise_db = noise_db
         self._stim_scaler = None
         self._suppress_resamp = suppress_resamp
+        self._enable_video = enable_video
+        self.video = None
         # placeholder for extra actions to do on flip-and-play
         self._on_every_flip = []
         self._on_next_flip = []
@@ -748,6 +750,14 @@ class ExperimentController(object):
     def monitor_size_pix(self):
         return np.array(self._monitor['SCREEN_SIZE_PIX'])
 
+# ############################### VIDEO METHODS ###############################
+    def load_video(self, file_name, pos=(0, 0), units='norm', center=True):
+        self.video = Video(self, file_name, pos, units)
+
+    def delete_video(self):
+        self.video._delete()
+        self.video = None
+
 # ############################### OPENGL METHODS ##############################
     def _setup_window(self, window_size, exp_name, full_screen, screen_num):
         # Use 16x sampling here
@@ -842,7 +852,8 @@ class ExperimentController(object):
         # this waits until everything is called, including last draw
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
         gl.glBegin(gl.GL_POINTS)
-        gl.glColor4f(0, 0, 0, 0)
+        if not self._enable_video:
+            gl.glColor4f(0, 0, 0, 0)
         gl.glVertex2i(10, 10)
         gl.glEnd()
         gl.glFinish()

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -8,6 +8,7 @@ from expyfun import ExperimentController, wait_secs, visual
 from expyfun._utils import (_TempDir, _hide_window, fake_button_press,
                             fake_mouse_click, requires_opengl21)
 from expyfun.stimuli import get_tdt_rates
+from functools import partial
 
 warnings.simplefilter('always')
 
@@ -246,7 +247,7 @@ def test_ec(ac=None, rd=None):
         ec.stop()
         ec.set_visible()
         ec.set_visible(False)
-        ec.call_on_every_flip(dummy_print, 'called start stimuli')
+        ec.call_on_every_flip(partial(dummy_print, 'called start stimuli'))
 
         #
         # First: identify_trial

--- a/expyfun/visual/__init__.py
+++ b/expyfun/visual/__init__.py
@@ -1,3 +1,3 @@
 from ._visual import (Text, Line, Triangle, Rectangle, Circle, RawImage,
                       Diamond, ConcentricCircles, FixationDot, _convert_color,
-                      _Triangular)
+                      _Triangular, Video)

--- a/expyfun/visual/_visual.py
+++ b/expyfun/visual/_visual.py
@@ -1084,6 +1084,7 @@ class Video(object):
         else:
             self._finished = True
             self.pause()
+        self._ec.check_force_quit()
 
     # PROPERTIES
     @property

--- a/expyfun/visual/_visual.py
+++ b/expyfun/visual/_visual.py
@@ -947,14 +947,14 @@ class Video(object):
         Units to use for the position. See ``check_units`` for options.
     scale : float
         The scale factor. 1 is native size (pixel-to-pixel), 2 is twice as
-        large, etc. Ignored if ``fill_window`` is ``True``. (Not implemented).
+        large, etc. Ignored if ``fill_window`` is ``True``.
     center : bool
         If ``False``, the elements of ``pos`` specify the position of the lower
         left corner of the video frame; otherwise they position the center of
         the frame.
     fill_window : bool
         If ``True``, scales the video to the size of the
-        ``ExperimentController`` window. (Not implemented).
+        ``ExperimentController`` window.
 
     Returns
     -------
@@ -962,12 +962,12 @@ class Video(object):
 
     Notes
     -----
-    This is a somewhat pared-down implementation of video playback. Looping and
-    scaling are not available, and the audio stream from the video file is
-    discarded. Timing of individual frames is relegated to the pyglet media
-    player's internal clock. Recommended for use only in paradigms where the
-    relative timing of audio and video are unimportant (e.g., if the video is
-    merely entertainment for the participant during a passive auditory task).
+    This is a somewhat pared-down implementation of video playback. Looping is
+    not available, and the audio stream from the video file is discarded.
+    Timing of individual frames is relegated to the pyglet media player's
+    internal clock. Recommended for use only in paradigms where the relative
+    timing of audio and video are unimportant (e.g., if the video is merely
+    entertainment for the participant during a passive auditory task).
     """
     def __init__(self, ec, file_name, pos=(0, 0), units='norm', scale=1.,
                  center=True, fill_window=False):
@@ -985,7 +985,7 @@ class Video(object):
         self._units = units
         self._center = center
         self._scale = scale
-        self.set_scale(scale)  # also calls set_pos
+        self.set_scale(scale, fill_window)  # also calls set_pos
 
     def play(self):
         """Play video from current position.
@@ -1027,7 +1027,7 @@ class Video(object):
             self._texture.width = self.source_width * self._scale
             self._texture.height = self.source_height * self._scale
 
-    def set_scale(self, scale):
+    def set_scale(self, scale=1., fill=False):
         """Set video scale.
 
         Parameters
@@ -1035,7 +1035,15 @@ class Video(object):
         scale : float
             The scale factor. 1 is native size (pixel-to-pixel), 2 is twice as
             large, etc.
+        fill : bool
+            If ``True``, ignores `scale` and scales the video to the size of
+            the parent ``ExperimentController`` window.
         """
+        if fill:
+            scale = self._ec.window_size_pix / np.array((self.source_width,
+                                                         self.source_height),
+                                                        dtype=float)
+            scale = scale.min()
         self._scale = float(scale)
         self._scale_texture()
         self.set_pos(self._pos, self._units, self._center)

--- a/expyfun/visual/tests/test_visuals.py
+++ b/expyfun/visual/tests/test_visuals.py
@@ -83,7 +83,8 @@ def test_visuals():
     with ExperimentController('test', **std_kwargs) as ec:
         ec.load_video(video_path)
         ec.video.play()
-        ec.wait_secs(0.5)
+        ec.video.set_scale(full=True)
+        ec.video.set_pos(pos=(0.1, 0), units='norm')
+        ec.wait_secs(0.2)
         ec.video.pause()
-        ec.video.delete()
-        ec.unload_video()
+        ec.delete_video()

--- a/expyfun/visual/tests/test_visuals.py
+++ b/expyfun/visual/tests/test_visuals.py
@@ -83,7 +83,11 @@ def test_visuals():
     with ExperimentController('test', **std_kwargs) as ec:
         ec.load_video(video_path)
         ec.video.play()
-        ec.video.set_scale(fill=True)
+        assert_raises(ValueError, ec.video.set_scale, 'foo')
+        assert_raises(ValueError, ec.video.set_scale, -1)
+        ec.video.set_scale('fill')
+        ec.video.set_scale('fit')
+        ec.video.set_scale(0.5)
         ec.video.set_pos(pos=(0.1, 0), units='norm')
         ec.wait_secs(0.2)
         ec.video.pause()

--- a/expyfun/visual/tests/test_visuals.py
+++ b/expyfun/visual/tests/test_visuals.py
@@ -83,7 +83,7 @@ def test_visuals():
     with ExperimentController('test', **std_kwargs) as ec:
         ec.load_video(video_path)
         ec.video.play()
-        ec.video.set_scale(full=True)
+        ec.video.set_scale(fill=True)
         ec.video.set_pos(pos=(0.1, 0), units='norm')
         ec.wait_secs(0.2)
         ec.video.pause()

--- a/expyfun/visual/tests/test_visuals.py
+++ b/expyfun/visual/tests/test_visuals.py
@@ -2,7 +2,7 @@ import warnings
 import numpy as np
 from nose.tools import assert_raises, assert_equal
 
-from expyfun import ExperimentController, visual
+from expyfun import ExperimentController, visual, fetch_data_file
 from expyfun._utils import _hide_window, requires_opengl21
 
 warnings.simplefilter('always')
@@ -76,3 +76,14 @@ def test_visuals():
         text.draw()
         text.set_color('red')
         text.draw()
+
+    # test video
+    std_kwargs.update(dict(enable_video=True, window_size=(640, 480)))
+    video_path = fetch_data_file('video/example-video.mp4')
+    with ExperimentController('test', **std_kwargs) as ec:
+        ec.load_video(video_path)
+        ec.video.play()
+        ec.wait_secs(0.5)
+        ec.video.pause()
+        ec.video.delete()
+        ec.unload_video()


### PR DESCRIPTION
This PR is a (hopefully) improved implementation of pyglet video playback.  The PRs for the other two attempts have been closed without merging.  It also changes the behavior of `ec.call_on_next_flip` and `ec.call_on_every_flip` by removing the internal call to `functools.partial` (see #269); henceforth, users must call `partial` (as needed) before adding functions to the on_next / on_every queue.  This has the advantage of allowing functions in the queue to be easily detected (via `ec.on_every_flip_functions.index()` and subsequently `pop()`ped.

The attempts at running travis with `trusty` caused pip to choke on mne, so I'm reverting to `precise` and avoiding the wget error via `--no-check-certificate`.

Closes #267 
Closes #269 