### PR TITLE
[ENH] Keyboard key releases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ doc/modules/generated/
 doc/source/generated/
 doc/source/auto_examples/
 
+# virtualenv
+env/
+

--- a/examples/experiments/keyrelease_demo.py
+++ b/examples/experiments/keyrelease_demo.py
@@ -12,8 +12,8 @@ inprecise timing.
 .. warning:
 
     It is currently not possible to get key-release events for Cedrus boxes or
-    TDT. Therefore, using get_presses(type='releases') or
-    get_presses(type='both') will throw an exception.
+    TDT. Therefore, using get_presses(kind='releases') or
+    get_presses(kind='both') will throw an exception.
 
 """
 # Author: Jasper van den Bosch <jasperb@uw.edu>
@@ -36,9 +36,9 @@ with ExperimentController('KeyPressAndReleaseDemo', screen_num=0,
     ec.wait_secs(isi)
 
     ###########################################
-    # listen_presses / while loop / get_presses(type='both')
+    # listen_presses / while loop / get_presses(kind='both')
     instruction = ("Press and release some keys\n\nlisten_presses()"
-                   "\nwhile loop {}\nget_presses(type='both')")
+                   "\nwhile loop {}\nget_presses(kind='both')")
     disp_time = wait_dur
     countdown = ec.current_time + disp_time
     ec.call_on_next_flip(ec.listen_presses)
@@ -51,7 +51,7 @@ with ExperimentController('KeyPressAndReleaseDemo', screen_num=0,
             # redraw text with updated disp_time
             ec.screen_text(instruction.format(disp_time))
             ec.flip()
-    events = ec.get_presses(type='both')
+    events = ec.get_presses(kind='both')
     ec.write_data_line('listen / while / get_presses', events)
     if not len(events):
         message = 'no keys pressed'

--- a/examples/experiments/keyrelease_demo.py
+++ b/examples/experiments/keyrelease_demo.py
@@ -1,10 +1,20 @@
 """
-=============
+=======================
 KeyPressAndRelease demo
-=============
+=======================
 
 This example demonstrates gathering key-releases as well as presses with
 the ExperimentController class.
+
+Please note that this currently only works for the keyboard, which has
+inprecise timing.
+
+.. warning:
+
+    It is currently not possible to get key-release events for Cedrus boxes or
+    TDT. Therefore, using get_presses(type='releases') or
+    get_presses(type='both') will throw an exception.
+
 """
 # Author: Jasper van den Bosch <jasperb@uw.edu>
 #

--- a/examples/experiments/keyrelease_demo.py
+++ b/examples/experiments/keyrelease_demo.py
@@ -1,0 +1,61 @@
+"""
+=============
+Keyrelease demo
+=============
+
+This example demonstrates the different keyrelease-gathering techniques available
+in the ExperimentController class.
+"""
+# Author: Dan McCloy <drmccloy@uw.edu>
+#
+# License: BSD (3-clause)
+
+import matplotlib.pyplot as plt
+
+from expyfun import ExperimentController
+import expyfun.analyze as ea
+
+print(__doc__)
+
+
+isi = 0.5
+wait_dur = 3.0
+msg_dur = 3.0
+
+with ExperimentController('KeyreleaseDemo', screen_num=0,
+                          window_size=[1280, 960], full_screen=False,
+                          stim_db=0, noise_db=0, output_dir=None,
+                          participant='foo', session='001',
+                          version='dev') as ec:
+    ec.wait_secs(isi)
+
+
+    ###########################################
+    # listen_releases / while loop / get_releases
+    disp_time = wait_dur
+    countdown = ec.current_time + disp_time
+    ec.call_on_next_flip(ec.listen_presses)
+    ec.screen_text('release some keys\n\nlisten_presses()'
+                   '\nwhile loop {}\nget_releases()'.format(disp_time))
+    ec.flip()
+    while ec.current_time < countdown:
+        cur_time = round(countdown - ec.current_time, 1)
+        if cur_time != disp_time:
+            disp_time = cur_time
+            # redraw text with updated disp_time
+            ec.screen_text('release some keys\n\nlisten_presses() '
+                           '\nwhile loop {}\nget_releases()'.format(disp_time))
+            ec.flip()
+    released = ec.get_releases()
+    ec.write_data_line('listen / while / get_releases', released)
+    if not len(released):
+        message = 'no keys released'
+    else:
+        message = ['{} released after {} secs\n'
+                   ''.format(key, round(time, 4)) for key, time in released]
+        message = ''.join(message)
+    ec.screen_prompt(message, msg_dur)
+    ec.wait_secs(isi)
+
+
+

--- a/examples/experiments/keyrelease_demo.py
+++ b/examples/experiments/keyrelease_demo.py
@@ -3,20 +3,16 @@
 Keyrelease demo
 =============
 
-This example demonstrates the different keyrelease-gathering techniques available
+This example demonstrates the keyrelease-gathering technique available
 in the ExperimentController class.
 """
 # Author: Dan McCloy <drmccloy@uw.edu>
 #
 # License: BSD (3-clause)
 
-import matplotlib.pyplot as plt
-
 from expyfun import ExperimentController
-import expyfun.analyze as ea
 
 print(__doc__)
-
 
 isi = 0.5
 wait_dur = 3.0
@@ -28,7 +24,6 @@ with ExperimentController('KeyreleaseDemo', screen_num=0,
                           participant='foo', session='001',
                           version='dev') as ec:
     ec.wait_secs(isi)
-
 
     ###########################################
     # listen_releases / while loop / get_releases
@@ -56,6 +51,3 @@ with ExperimentController('KeyreleaseDemo', screen_num=0,
         message = ''.join(message)
     ec.screen_prompt(message, msg_dur)
     ec.wait_secs(isi)
-
-
-

--- a/examples/experiments/keyrelease_demo.py
+++ b/examples/experiments/keyrelease_demo.py
@@ -31,7 +31,7 @@ with ExperimentController('KeyreleaseDemo', screen_num=0,
     countdown = ec.current_time + disp_time
     ec.call_on_next_flip(ec.listen_presses)
     ec.screen_text('release some keys\n\nlisten_presses()'
-                   '\nwhile loop {}\nget_releases()'.format(disp_time))
+                   '\nwhile loop {}\nget_presses()'.format(disp_time))
     ec.flip()
     while ec.current_time < countdown:
         cur_time = round(countdown - ec.current_time, 1)
@@ -39,15 +39,15 @@ with ExperimentController('KeyreleaseDemo', screen_num=0,
             disp_time = cur_time
             # redraw text with updated disp_time
             ec.screen_text('release some keys\n\nlisten_presses() '
-                           '\nwhile loop {}\nget_releases()'.format(disp_time))
+                           '\nwhile loop {}\nget_presses()'.format(disp_time))
             ec.flip()
-    released = ec.get_releases()
-    ec.write_data_line('listen / while / get_releases', released)
+    released = ec.get_presses(releases=True)
+    ec.write_data_line('listen / while / get_presses', released)
     if not len(released):
         message = 'no keys released'
     else:
-        message = ['{} released after {} secs\n'
-                   ''.format(key, round(time, 4)) for key, time in released]
+        message = ['{} {} after {} secs\n'
+                   ''.format(k, r, round(t, 4)) for k, t, r in released]
         message = ''.join(message)
     ec.screen_prompt(message, msg_dur)
     ec.wait_secs(isi)

--- a/examples/experiments/keyrelease_demo.py
+++ b/examples/experiments/keyrelease_demo.py
@@ -1,10 +1,10 @@
 """
 =============
-Keyrelease demo
+KeyPressAndRelease demo
 =============
 
-This example demonstrates the keyrelease-gathering technique available
-in the ExperimentController class.
+This example demonstrates gathering key-releases as well as presses with
+the ExperimentController class.
 """
 # Author: Jasper van den Bosch <jasperb@uw.edu>
 #
@@ -18,7 +18,7 @@ isi = 0.5
 wait_dur = 3.0
 msg_dur = 3.0
 
-with ExperimentController('KeyreleaseDemo', screen_num=0,
+with ExperimentController('KeyPressAndReleaseDemo', screen_num=0,
                           window_size=[1280, 960], full_screen=False,
                           stim_db=0, noise_db=0, output_dir=None,
                           participant='foo', session='001',
@@ -26,28 +26,28 @@ with ExperimentController('KeyreleaseDemo', screen_num=0,
     ec.wait_secs(isi)
 
     ###########################################
-    # listen_releases / while loop / get_releases
+    # listen_presses / while loop / get_presses(type='both')
+    instruction = ("Press and release some keys\n\nlisten_presses()"
+                   "\nwhile loop {}\nget_presses(type='both')")
     disp_time = wait_dur
     countdown = ec.current_time + disp_time
     ec.call_on_next_flip(ec.listen_presses)
-    ec.screen_text('release some keys\n\nlisten_presses()'
-                   '\nwhile loop {}\nget_presses()'.format(disp_time))
+    ec.screen_text(instruction.format(disp_time))
     ec.flip()
     while ec.current_time < countdown:
         cur_time = round(countdown - ec.current_time, 1)
         if cur_time != disp_time:
             disp_time = cur_time
             # redraw text with updated disp_time
-            ec.screen_text('release some keys\n\nlisten_presses() '
-                           '\nwhile loop {}\nget_presses()'.format(disp_time))
+            ec.screen_text(instruction.format(disp_time))
             ec.flip()
-    released = ec.get_presses(releases=True)
-    ec.write_data_line('listen / while / get_presses', released)
-    if not len(released):
-        message = 'no keys released'
+    events = ec.get_presses(type='both')
+    ec.write_data_line('listen / while / get_presses', events)
+    if not len(events):
+        message = 'no keys pressed'
     else:
         message = ['{} {} after {} secs\n'
-                   ''.format(k, r, round(t, 4)) for k, t, r in released]
+                   ''.format(k, r, round(t, 4)) for k, t, r in events]
         message = ''.join(message)
     ec.screen_prompt(message, msg_dur)
     ec.wait_secs(isi)

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -944,8 +944,8 @@ class ExperimentController(object):
         -------
         presses : list
             Returns a list of tuples with key events. Each tuple's first value
-            will be the key pressed. If timestamp==True, the second value is
-            the time for the event. The last value is a string indicating if
+            will be the key pressed. If ``timestamp==True``, the second value
+            is the time for the event. The last value is a string indicating if
             this was a key press or release event.
 
         See Also

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -935,7 +935,7 @@ class ExperimentController(object):
             A time relative to which timestamping is done. Ignored if
             timestamp==False.  If ``None``, timestamps are relative to the time
             `listen_presses` was last called.
-        releases : False | bool 
+        releases : False | bool
             Whether key-release events should be returned as well.
 
         Returns

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -923,6 +923,12 @@ class ExperimentController(object):
         """Get the entire keyboard / button box buffer. This will also clear
         events that are not requested per ``type``.
 
+        .. warning:
+
+            It is currently not possible to get key-release events for Cedrus
+            boxes or TDT. Therefore, using get_presses(type='releases') or
+            get_presses(type='both') will throw an exception.
+
         Parameters
         ----------
         live_keys : list | None

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -950,6 +950,38 @@ class ExperimentController(object):
         return self._response_handler.get_presses(live_keys, timestamp,
                                                   relative_to)
 
+    def get_releases(self, live_keys=None, timestamp=True, relative_to=None):
+        """Get the entire keyboard / button box buffer for key-releases.
+
+        Parameters
+        ----------
+        live_keys : list | None
+            List of strings indicating acceptable keys or buttons. Other data
+            types are cast as strings, so a list of ints will also work.
+            ``None`` accepts all keypresses.
+        timestamp : bool
+            Whether the keyrelease should be timestamped. If True, returns the
+            button release time relative to the value given in `relative_to`.
+        relative_to : None | float
+            A time relative to which timestamping is done. Ignored if
+            timestamp==False.  If ``None``, timestamps are relative to the time
+            `listen_presses` was last called.
+
+        Returns
+        -------
+        presses : list
+            If timestamp==False, returns a list of strings indicating which
+            keys were released. Otherwise, returns a list of tuples
+            (str, float) of keys and their timestamps.
+
+        See Also
+        --------
+        ExperimentController.listen_presses
+        ExperimentController.get_presses
+        """
+        return self._response_handler.get_releases(live_keys, timestamp,
+                                                  relative_to)
+
     def wait_one_press(self, max_wait=np.inf, min_wait=0.0, live_keys=None,
                        timestamp=True, relative_to=None):
         """Returns only the first button pressed after min_wait.

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -918,7 +918,8 @@ class ExperimentController(object):
         """
         self._response_handler.listen_presses()
 
-    def get_presses(self, live_keys=None, timestamp=True, relative_to=None):
+    def get_presses(self, live_keys=None, timestamp=True, relative_to=None,
+                    releases=False):
         """Get the entire keyboard / button box buffer.
 
         Parameters
@@ -934,6 +935,8 @@ class ExperimentController(object):
             A time relative to which timestamping is done. Ignored if
             timestamp==False.  If ``None``, timestamps are relative to the time
             `listen_presses` was last called.
+        releases : False | bool 
+            Whether key-release events should be returned as well.
 
         Returns
         -------
@@ -941,6 +944,8 @@ class ExperimentController(object):
             If timestamp==False, returns a list of strings indicating which
             keys were pressed. Otherwise, returns a list of tuples
             (str, float) of keys and their timestamps.
+            If releases is True, the last value in the tuple will be a string,
+            either 'press' or 'release'.
 
         See Also
         --------
@@ -949,39 +954,7 @@ class ExperimentController(object):
         ExperimentController.wait_for_presses
         """
         return self._response_handler.get_presses(live_keys, timestamp,
-                                                  relative_to)
-
-    def get_releases(self, live_keys=None, timestamp=True, relative_to=None):
-        """Get the entire keyboard / button box buffer for key-releases.
-
-        Parameters
-        ----------
-        live_keys : list | None
-            List of strings indicating acceptable keys or buttons. Other data
-            types are cast as strings, so a list of ints will also work.
-            ``None`` accepts all keypresses.
-        timestamp : bool
-            Whether the keyrelease should be timestamped. If True, returns the
-            button release time relative to the value given in `relative_to`.
-        relative_to : None | float
-            A time relative to which timestamping is done. Ignored if
-            timestamp==False.  If ``None``, timestamps are relative to the time
-            `listen_presses` was last called.
-
-        Returns
-        -------
-        presses : list
-            If timestamp==False, returns a list of strings indicating which
-            keys were released. Otherwise, returns a list of tuples
-            (str, float) of keys and their timestamps.
-
-        See Also
-        --------
-        ExperimentController.listen_presses
-        ExperimentController.get_presses
-        """
-        return self._response_handler.get_releases(live_keys, timestamp,
-                                                   relative_to)
+                                                  relative_to, releases)
 
     def wait_one_press(self, max_wait=np.inf, min_wait=0.0, live_keys=None,
                        timestamp=True, relative_to=None):
@@ -1072,8 +1045,8 @@ class ExperimentController(object):
         """
         # This function will typically be called by self._response_handler
         # after it retrieves some button presses
-        for key, stamp in pressed:
-            self.write_data_line('keypress', key, stamp)
+        for key, stamp, eventType in pressed:
+            self.write_data_line('key'+eventType, key, stamp)
 
     def check_force_quit(self):
         """Check to see if any force quit keys were pressed

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -919,8 +919,9 @@ class ExperimentController(object):
         self._response_handler.listen_presses()
 
     def get_presses(self, live_keys=None, timestamp=True, relative_to=None,
-                    releases=False):
-        """Get the entire keyboard / button box buffer.
+                    type='presses'):
+        """Get the entire keyboard / button box buffer. This will also clear
+        events that are not requested per ``type``.
 
         Parameters
         ----------
@@ -955,7 +956,7 @@ class ExperimentController(object):
         ExperimentController.wait_for_presses
         """
         return self._response_handler.get_presses(live_keys, timestamp,
-                                                  relative_to, releases)
+                                                  relative_to, type)
 
     def wait_one_press(self, max_wait=np.inf, min_wait=0.0, live_keys=None,
                        timestamp=True, relative_to=None):

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -935,8 +935,9 @@ class ExperimentController(object):
             A time relative to which timestamping is done. Ignored if
             timestamp==False.  If ``None``, timestamps are relative to the time
             `listen_presses` was last called.
-        releases : False | bool
-            Whether key-release events should be returned as well.
+        type : string
+            Which key events to return. One of ``presses``, ``releases`` or
+            ``both``. (default ``presses``)
 
         Returns
         -------

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -980,7 +980,7 @@ class ExperimentController(object):
         ExperimentController.get_presses
         """
         return self._response_handler.get_releases(live_keys, timestamp,
-                                                  relative_to)
+                                                   relative_to)
 
     def wait_one_press(self, max_wait=np.inf, min_wait=0.0, live_keys=None,
                        timestamp=True, relative_to=None):

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -943,11 +943,10 @@ class ExperimentController(object):
         Returns
         -------
         presses : list
-            If timestamp==False, returns a list of strings indicating which
-            keys were pressed. Otherwise, returns a list of tuples
-            (str, float) of keys and their timestamps.
-            If releases is True, the last value in the tuple will be a string,
-            either 'press' or 'release'.
+            Returns a list of tuples with key events. Each tuple's first value
+            will be the key pressed. If timestamp==True, the second value is
+            the time for the event. The last value is a string indicating if
+            this was a key press or release event.
 
         See Also
         --------

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -919,7 +919,7 @@ class ExperimentController(object):
         self._response_handler.listen_presses()
 
     def get_presses(self, live_keys=None, timestamp=True, relative_to=None,
-                    type='presses'):
+                    kind='presses'):
         """Get the entire keyboard / button box buffer. This will also clear
         events that are not requested per ``type``.
 
@@ -942,7 +942,7 @@ class ExperimentController(object):
             A time relative to which timestamping is done. Ignored if
             timestamp==False.  If ``None``, timestamps are relative to the time
             `listen_presses` was last called.
-        type : string
+        kind : string
             Which key events to return. One of ``presses``, ``releases`` or
             ``both``. (default ``presses``)
 
@@ -961,7 +961,7 @@ class ExperimentController(object):
         ExperimentController.wait_for_presses
         """
         return self._response_handler.get_presses(live_keys, timestamp,
-                                                  relative_to, type)
+                                                  relative_to, kind)
 
     def wait_one_press(self, max_wait=np.inf, min_wait=0.0, live_keys=None,
                        timestamp=True, relative_to=None):

--- a/expyfun/_input_controllers.py
+++ b/expyfun/_input_controllers.py
@@ -32,7 +32,7 @@ class Keyboard(object):
         _retrieve_events
     """
     key_event_types = {'presses': ['press'], 'releases': ['release'],
-                     'both': ['press', 'release']}
+                       'both': ['press', 'release']}
 
     def __init__(self, ec, force_quit_keys):
         self.master_clock = ec._master_clock
@@ -496,7 +496,8 @@ class CedrusBox(Keyboard):
         self._dev.poll_for_response()
         while self._dev.response_queue_size() > 0:
             key = self._dev.get_next_response()
-            press_or_release = {True: 'press', False: 'release'}[key['pressed']]
+            press_or_release = {True: 'press',
+                                False: 'release'}[key['pressed']]
             key = [str(key['key'] + 1), key['time'] / 1000., press_or_release]
             self._keyboard_buffer.append(key)
             self._dev.poll_for_response()

--- a/expyfun/_input_controllers.py
+++ b/expyfun/_input_controllers.py
@@ -31,7 +31,7 @@ class Keyboard(object):
         _clear_events
         _retrieve_events
     """
-    keyEventTypes = {'presses': ['press'], 'releases': ['release'],
+    key_event_types = {'presses': ['press'], 'releases': ['release'],
                      'both': ['press', 'release']}
 
     def __init__(self, ec, force_quit_keys):
@@ -74,7 +74,7 @@ class Keyboard(object):
         targets = []
 
         for key in self._keyboard_buffer:
-            if key[2] in self.keyEventTypes[kind]:
+            if key[2] in self.key_event_types[kind]:
                 if live_keys is None or key[0] in live_keys:
                     targets.append(key)
         return targets
@@ -89,8 +89,8 @@ class Keyboard(object):
             from pyglet.window import key
             this_key = key.symbol_string(symbol).lower()
             this_key = this_key.lstrip('_').lstrip('NUM_')
-        pressOrRelease = {True: 'press', False: 'release'}[isPress]
-        self._keyboard_buffer.append((this_key, key_time, pressOrRelease))
+        press_or_release = {True: 'press', False: 'release'}[isPress]
+        self._keyboard_buffer.append((this_key, key_time, press_or_release))
 
     def _on_pyglet_keyrelease(self, symbol, modifiers, emulated=False):
         self._on_pyglet_keypress(symbol, modifiers, emulated=emulated,
@@ -106,9 +106,9 @@ class Keyboard(object):
     def get_presses(self, live_keys, timestamp, relative_to, kind='presses'):
         """Get the current entire keyboard / button box buffer.
         """
-        if kind not in self.keyEventTypes.keys():
+        if kind not in self.key_event_types.keys():
             raise ValueError('Kind argument must be one of: '+', '.join(
-                             self.keyEventTypes.keys()))
+                             self.key_event_types.keys()))
         events = []
         if timestamp and relative_to is None:
             if self.listen_start is None:
@@ -180,7 +180,7 @@ class Keyboard(object):
             self.log_presses(events)
             keys = [k[0] for k in events]
             self.check_force_quit(keys)
-            events = [e for e in events if e[2] in self.keyEventTypes[kind]]
+            events = [e for e in events if e[2] in self.key_event_types[kind]]
             if timestamp:
                 events = [(k, s - relative_to, t) for (k, s, t) in events]
             else:
@@ -496,14 +496,14 @@ class CedrusBox(Keyboard):
         self._dev.poll_for_response()
         while self._dev.response_queue_size() > 0:
             key = self._dev.get_next_response()
-            pressOrRelease = {True: 'press', False: 'release'}[key['pressed']]
-            key = [str(key['key'] + 1), key['time'] / 1000., pressOrRelease]
+            press_or_release = {True: 'press', False: 'release'}[key['pressed']]
+            key = [str(key['key'] + 1), key['time'] / 1000., press_or_release]
             self._keyboard_buffer.append(key)
             self._dev.poll_for_response()
         # check to see if we have matches
         targets = []
         for key in self._keyboard_buffer:
-            if key[2] in self.keyEventTypes[kind]:
+            if key[2] in self.key_event_types[kind]:
                 if live_keys is None or key[0] in live_keys:
                     targets.append(key)
         return targets

--- a/expyfun/_input_controllers.py
+++ b/expyfun/_input_controllers.py
@@ -31,8 +31,8 @@ class Keyboard(object):
         _clear_events
         _retrieve_events
     """
-    keyEventTypes = {'presses':['press'], 'releases':['release'],
-                          'both':['press','release']}
+    keyEventTypes = {'presses': ['press'], 'releases': ['release'],
+                     'both': ['press', 'release']}
 
     def __init__(self, ec, force_quit_keys):
         self.master_clock = ec._master_clock

--- a/expyfun/_input_controllers.py
+++ b/expyfun/_input_controllers.py
@@ -72,12 +72,12 @@ class Keyboard(object):
         targets = []
         for key in self._keyboard_buffer:
             if key[2] == 'release' and not releases:
-                continue #filter out releases
+                continue  # filter out releases
             if live_keys is None or key[0] in live_keys:
                 targets.append(key)
         return targets
 
-    def _on_pyglet_keypress(self, symbol, modifiers, emulated=False, 
+    def _on_pyglet_keypress(self, symbol, modifiers, emulated=False,
                             isPress=True):
         """Handler for on_key_press pyglet events"""
         key_time = clock()
@@ -87,11 +87,11 @@ class Keyboard(object):
             from pyglet.window import key
             this_key = key.symbol_string(symbol).lower()
             this_key = this_key.lstrip('_').lstrip('NUM_')
-        pressOrRelease = {True:'press', False: 'release'}[isPress]
+        pressOrRelease = {True: 'press', False: 'release'}[isPress]
         self._keyboard_buffer.append((this_key, key_time, pressOrRelease))
 
     def _on_pyglet_keyrelease(self, symbol, modifiers, emulated=False):
-        self._on_pyglet_keypress(symbol, modifiers, emulated=emulated, 
+        self._on_pyglet_keypress(symbol, modifiers, emulated=emulated,
                                  isPress=False)
 
     def listen_presses(self):
@@ -167,7 +167,8 @@ class Keyboard(object):
         if len(keys):
             raise RuntimeError('Quit key pressed')
 
-    def _correct_presses(self, pressed, timestamp, relative_to, releases=False):
+    def _correct_presses(self, pressed, timestamp, relative_to,
+                         releases=False):
         """Correct timing of presses and check for quit press"""
         correctedEvents = []
         if len(pressed):
@@ -182,7 +183,7 @@ class Keyboard(object):
                 if releases:
                     correctedEvent.append(event[2])
                 elif event[2] == 'release':
-                    continue # removes releases.
+                    continue  # removes releases.
                 if len(correctedEvent) > 1:
                     correctedEvent = tuple(correctedEvent)
                 else:
@@ -499,7 +500,7 @@ class CedrusBox(Keyboard):
         self._dev.poll_for_response()
         while self._dev.response_queue_size() > 0:
             key = self._dev.get_next_response()
-            pressOrRelease = {True:'press', False: 'release'}[key['pressed']]
+            pressOrRelease = {True: 'press', False: 'release'}[key['pressed']]
             key = [str(key['key'] + 1), key['time'] / 1000., pressOrRelease]
             self._keyboard_buffer.append(key)
             self._dev.poll_for_response()
@@ -507,8 +508,7 @@ class CedrusBox(Keyboard):
         targets = []
         for key in self._keyboard_buffer:
             if key[2] == 'release' and not releases:
-                continue #filter out releases
+                continue  # filter out releases
             if live_keys is None or key[0] in live_keys:
                 targets.append(key)
         return targets
-

--- a/expyfun/_input_controllers.py
+++ b/expyfun/_input_controllers.py
@@ -530,4 +530,5 @@ class CedrusBox(Keyboard):
         return targets
 
     def get_releases(self, live_keys, timestamp, relative_to):
-        raise NotImplementedError('Key releases not implemented for CedrusBox.')
+        msg = 'Key releases not implemented for CedrusBox.'
+        raise NotImplementedError(msg)

--- a/expyfun/_sound_controllers.py
+++ b/expyfun/_sound_controllers.py
@@ -21,7 +21,12 @@ _driver = _opts_dict[sys.platform] if not _use_silent else ('silent',)
 pyglet.options['audio'] = _driver
 
 # these must follow the above option setting, so PEP8 complains
+#try:
 from pyglet.media import Player, AudioFormat, SourceGroup  # noqa
+#except ImportError:
+#    from pyglet.media import Player, AudioFormat
+#    from mock import Mock
+#    SourceGroup = Mock()  # noqa
 try:
     from pyglet.media import StaticMemorySource
 except ImportError:

--- a/expyfun/_sound_controllers.py
+++ b/expyfun/_sound_controllers.py
@@ -21,12 +21,7 @@ _driver = _opts_dict[sys.platform] if not _use_silent else ('silent',)
 pyglet.options['audio'] = _driver
 
 # these must follow the above option setting, so PEP8 complains
-#try:
 from pyglet.media import Player, AudioFormat, SourceGroup  # noqa
-#except ImportError:
-#    from pyglet.media import Player, AudioFormat
-#    from mock import Mock
-#    SourceGroup = Mock()  # noqa
 try:
     from pyglet.media import StaticMemorySource
 except ImportError:

--- a/expyfun/_tdt_controller.py
+++ b/expyfun/_tdt_controller.py
@@ -298,7 +298,7 @@ class TDTController(Keyboard):
         self._trigger(7)
         self._clear_keyboard_events()
 
-    def _retrieve_events(self, live_keys):
+    def _retrieve_events(self, live_keys, releases=False):
         """Values and timestamps currently in keyboard buffer.
         """
         # get values from the tdt

--- a/expyfun/_tdt_controller.py
+++ b/expyfun/_tdt_controller.py
@@ -298,9 +298,11 @@ class TDTController(Keyboard):
         self._trigger(7)
         self._clear_keyboard_events()
 
-    def _retrieve_events(self, live_keys, releases=False):
+    def _retrieve_events(self, live_keys, type='presses'):
         """Values and timestamps currently in keyboard buffer.
         """
+        if type != 'presses':
+            raise RuntimeError("TDT Cannot get key release events")
         # get values from the tdt
         press_count = int(round(self.rpcox.GetTagVal('npressabs')))
         if press_count > 0:

--- a/expyfun/_version.py
+++ b/expyfun/_version.py
@@ -1,2 +1,1 @@
 __version__ = '2.0.0.dev0'
-__fork__ = 'ilogue'

--- a/expyfun/_version.py
+++ b/expyfun/_version.py
@@ -1,1 +1,2 @@
 __version__ = '2.0.0.dev0'
+__fork__ = 'ilogue'

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -196,7 +196,15 @@ def test_ec(ac=None, rd=None):
         assert_equal(ec.wait_for_presses(0.01, timestamp=False), [])
         assert_raises(ValueError, ec.get_presses)
         ec.listen_presses()
+        if this_rd == 'tdt':
+            # TDT does not have key release events, so should raise an
+            # exception if asked for them:
+            assert_raises(RuntimeError, ec.get_presses, type='releases')
+            assert_raises(RuntimeError, ec.get_presses, type='both')
         assert_equal(ec.get_presses(), [])
+        assert_equal(ec.get_presses(type='presses'), [])
+        assert_equal(ec.get_presses(type='both'), [])
+        assert_equal(ec.get_presses(type='releases'), [])
         ec.clear_buffer()
         ec.set_noise_db(0)
         ec.set_stim_db(20)

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -196,15 +196,16 @@ def test_ec(ac=None, rd=None):
         assert_equal(ec.wait_for_presses(0.01, timestamp=False), [])
         assert_raises(ValueError, ec.get_presses)
         ec.listen_presses()
+        assert_equal(ec.get_presses(), [])
+        assert_equal(ec.get_presses(type='presses'), [])
         if this_rd == 'tdt':
             # TDT does not have key release events, so should raise an
             # exception if asked for them:
             assert_raises(RuntimeError, ec.get_presses, type='releases')
             assert_raises(RuntimeError, ec.get_presses, type='both')
-        assert_equal(ec.get_presses(), [])
-        assert_equal(ec.get_presses(type='presses'), [])
-        assert_equal(ec.get_presses(type='both'), [])
-        assert_equal(ec.get_presses(type='releases'), [])
+        else:
+            assert_equal(ec.get_presses(type='both'), [])
+            assert_equal(ec.get_presses(type='releases'), [])
         ec.clear_buffer()
         ec.set_noise_db(0)
         ec.set_stim_db(20)

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -335,7 +335,7 @@ def test_button_presses_and_window_size():
         warnings.simplefilter('always')
         fake_button_press(ec, '1', 0.3)
         assert_equal(ec.screen_prompt('press 1', live_keys=['1'],
-                                      max_wait=1.5), '1')
+                                      max_wait=1.5), ('1', 'press'))
         ec.screen_text('press 1 again')
         ec.flip()
         fake_button_press(ec, '1', 0.3)
@@ -344,7 +344,7 @@ def test_button_presses_and_window_size():
         ec.flip()
         fake_button_press(ec, '1', 0.3)
         out = ec.wait_for_presses(1.5, live_keys=['1'], timestamp=False)
-        assert_equal(out[0], '1')
+        assert_equal(out[0], ('1', 'press'))
 
 
 @_hide_window

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -197,15 +197,16 @@ def test_ec(ac=None, rd=None):
         assert_raises(ValueError, ec.get_presses)
         ec.listen_presses()
         assert_equal(ec.get_presses(), [])
-        assert_equal(ec.get_presses(type='presses'), [])
+        assert_equal(ec.get_presses(kind='presses'), [])
+        assert_raises(ValueError, ec.get_presses, kind='foo')
         if this_rd == 'tdt':
             # TDT does not have key release events, so should raise an
             # exception if asked for them:
-            assert_raises(RuntimeError, ec.get_presses, type='releases')
-            assert_raises(RuntimeError, ec.get_presses, type='both')
+            assert_raises(RuntimeError, ec.get_presses, kind='releases')
+            assert_raises(RuntimeError, ec.get_presses, kind='both')
         else:
-            assert_equal(ec.get_presses(type='both'), [])
-            assert_equal(ec.get_presses(type='releases'), [])
+            assert_equal(ec.get_presses(kind='both'), [])
+            assert_equal(ec.get_presses(kind='releases'), [])
         ec.clear_buffer()
         ec.set_noise_db(0)
         ec.set_stim_db(20)


### PR DESCRIPTION
Collecting key-release events

~~I've added a `get_releases()` method on `ExperimentController` to be able to get key release events.~~

~~There's room for refactoring as I've just duplicated most of the keypress code.~~

~~I haven't been able to run/ adapt the tests properly since nosetest in a virtualenv uses global packages and I get the _check_pyglet error.~~ *resolved this with http://stackoverflow.com/a/864967* 
I have added an example script.

Summary of todo's:

- [x] fix docstring
- [x] fix event type argument
- [x] make press events dependent on argument
- [x] fix event tuple structure
- [x] fix demo
- [x] runtime error for TDT
- [x] EC tests