### PR TITLE
TDT delay

### DIFF
--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -12,6 +12,7 @@ import warnings
 from os import path as op
 from functools import partial
 import traceback as tb
+from numbers import Integral
 try:
     import pyglet
     from pyglet import gl
@@ -29,7 +30,6 @@ from ._input_controllers import Keyboard, CedrusBox, Mouse
 from .stimuli._filter import resample
 from .visual import Text, Rectangle, Video, _convert_color
 from ._git import assert_version
-
 
 # Note: ec._trial_progress has three values:
 # 1. 'stopped', which ec.identify_trial turns into...
@@ -93,8 +93,6 @@ class ExperimentController(object):
         default the mode is 'dummy', since setting up the parallel port
         can be a pain. Can also be a dict with entries 'type' ('parallel')
         and 'address' (e.g., '/dev/parport0').
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see expyfun.verbose).
     check_rms : str | None
         Method to use in checking stimulus RMS to ensure appropriate levels.
         Possible values are ``None``, ``wholefile``, and ``windowed`` (the
@@ -107,6 +105,14 @@ class ExperimentController(object):
         the expected version of the expyfun codebase is being used when running
         experiments. To override version checking (e.g., during development)
         use ``version='dev'``.
+    tdt_delay : int | None
+        The number of milliseconds to delay the audio signal so that it
+        coincides with the visual signal. Defualt is ``None``, which uses the
+        value from the configuration file (or sets it to 0 if that value is not
+        defined in the file). Otherwise it can be any non-negative integer.
+        This parameter has no effect if the TDT is not the audio device.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see expyfun.verbose).
 
     Returns
     -------
@@ -126,13 +132,14 @@ class ExperimentController(object):
                  full_screen=True, force_quit=None, participant=None,
                  monitor=None, trigger_controller=None, session=None,
                  verbose=None, check_rms='windowed', suppress_resamp=False,
-                 version=None, enable_video=False):
+                 version=None, enable_video=False, tdt_delay=None):
         # initialize some values
         self._stim_fs = stim_fs
         self._stim_rms = stim_rms
         self._stim_db = stim_db
         self._noise_db = noise_db
         self._stim_scaler = None
+        self._tdt_delay = tdt_delay
         self._suppress_resamp = suppress_resamp
         self._enable_video = enable_video
         self.video = None
@@ -279,12 +286,35 @@ class ExperimentController(object):
             #
             # Initialize devices
             #
+            # Handle the tdt_delay parameter
+            if self._tdt_delay is not None:
+                if self.audio_type == 'tdt':
+                    try:
+                        np.isfinite(self._tdt_delay)  # bombs if not numeric
+                    except:
+                        raise TypeError('tdt_delay must be a non-negative'
+                                        'integer')
+                    if self._tdt_delay < 0 or not np.isfinite(self._tdt_delay):
+                        raise ValueError('tdt_delay must be a non-negative'
+                                         'integer')
+                    if not issubclass(type(self._tdt_delay)):
+                        self._tdt_delay = int(np.round(self._tdt_delay))
+                        logger.warning('Expyfun: tdt_delay must be int.'
+                                       'Rounding and casting.')
+                else:
+                    logger.warning('Expyfun: tdt_delay parameter has no effect'
+                                   'when not using the TDT for audio.')
 
             # Audio (and for TDT, potentially keyboard)
             if self.audio_type == 'tdt':
                 logger.info('Expyfun: Setting up TDT')
+                if (self._tdt_delay is not None and
+                        'TDT_DELAY' not in audio_controller):
+                    audio_controller['TDT_DELAY'] = str(self._tdt_delay)
                 self._ac = TDTController(audio_controller)
                 self.audio_type = self._ac.model
+                if self._tdt_delay is not None:
+                    self._ac._set_delay(delay=self._tdt_delay)
             elif self.audio_type == 'pyglet':
                 self._ac = PygletSoundController(self, self.stim_fs)
             else:
@@ -1871,6 +1901,12 @@ class ExperimentController(object):
         """Timestamp from the experiment master clock.
         """
         return self._master_clock()
+
+    @property
+    def tdt_delay(self):
+        """Time that TDT delays audioa nd triggers for AV synchrony.
+        """
+        return self._tdt_delay
 
     @property
     def _fs_mismatch(self):

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -12,7 +12,6 @@ import warnings
 from os import path as op
 from functools import partial
 import traceback as tb
-from numbers import Integral
 try:
     import pyglet
     from pyglet import gl

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -286,18 +286,22 @@ class ExperimentController(object):
             #
             # Initialize devices
             #
+
             # Handle the tdt_delay parameter
             if self._tdt_delay is not None:
                 if self.audio_type == 'tdt':
                     try:
                         np.isfinite(self._tdt_delay)  # bombs if not numeric
                     except:
-                        raise TypeError('tdt_delay must be a non-negative'
+                        raise TypeError('tdt_delay must be a non-negative '
+                                        'integer')
+                    if not np.isscalar(self._tdt_delay):
+                        raise TypeError('tdt_delay must be a non-negative '
                                         'integer')
                     if self._tdt_delay < 0 or not np.isfinite(self._tdt_delay):
-                        raise ValueError('tdt_delay must be a non-negative'
+                        raise ValueError('tdt_delay must be a non-negative '
                                          'integer')
-                    if not issubclass(type(self._tdt_delay)):
+                    if not issubclass(type(self._tdt_delay), Integral):
                         self._tdt_delay = int(np.round(self._tdt_delay))
                         logger.warning('Expyfun: tdt_delay must be int.'
                                        'Rounding and casting.')
@@ -313,8 +317,6 @@ class ExperimentController(object):
                     audio_controller['TDT_DELAY'] = str(self._tdt_delay)
                 self._ac = TDTController(audio_controller)
                 self.audio_type = self._ac.model
-                if self._tdt_delay is not None:
-                    self._ac._set_delay(delay=self._tdt_delay)
             elif self.audio_type == 'pyglet':
                 self._ac = PygletSoundController(self, self.stim_fs)
             else:

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -110,7 +110,8 @@ class ExperimentController(object):
         coincides with the visual signal. Defualt is ``None``, which uses the
         value from the configuration file (or sets it to 0 if that value is not
         defined in the file). Otherwise it can be any non-negative integer.
-        This parameter has no effect if the TDT is not the audio device.
+        Floats will be rounded. This parameter has no effect if the TDT is not
+        the audio device.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see expyfun.verbose).
 
@@ -290,21 +291,9 @@ class ExperimentController(object):
             # Handle the tdt_delay parameter
             if self._tdt_delay is not None:
                 if self.audio_type == 'tdt':
-                    try:
-                        np.isfinite(self._tdt_delay)  # bombs if not numeric
-                    except:
-                        raise TypeError('tdt_delay must be a non-negative '
-                                        'integer')
-                    if not np.isscalar(self._tdt_delay):
-                        raise TypeError('tdt_delay must be a non-negative '
-                                        'integer')
-                    if self._tdt_delay < 0 or not np.isfinite(self._tdt_delay):
-                        raise ValueError('tdt_delay must be a non-negative '
-                                         'integer')
-                    if not issubclass(type(self._tdt_delay), Integral):
-                        self._tdt_delay = int(np.round(self._tdt_delay))
-                        logger.warning('Expyfun: tdt_delay must be int.'
-                                       'Rounding and casting.')
+                    self._tdt_delay = int(np.round(self._tdt_delay))
+                    if self._tdt_delay < 0:
+                        raise ValueError('tdt_delay must be a non-negative.')
                 else:
                     logger.warning('Expyfun: tdt_delay parameter has no effect'
                                    'when not using the TDT for audio.')

--- a/expyfun/_tdt_controller.py
+++ b/expyfun/_tdt_controller.py
@@ -244,15 +244,18 @@ class TDTController(Keyboard):
         self._trigger(5)
         logger.debug('Expyfun: Resetting TDT ring buffer')
 
-    def _set_delay(self, delay, delay_trig):
+    def _set_delay(self, delay=None, delay_trig=None):
         """Set the delay (in ms) of the system
         """
         assert isinstance(delay, int)  # this should never happen
         assert isinstance(delay_trig, int)
-        self.rpcox.SetTagVal('onsetdel', delay)
-        logger.info('Expyfun: Setting TDT delay to %s' % delay)
-        self.rpcox.SetTagVal('trigdel', delay_trig)
-        logger.info('Expyfun: Setting TDT trigger delay to %s' % delay_trig)
+        if delay is not None:
+            self.rpcox.SetTagVal('onsetdel', delay)
+            logger.info('Expyfun: Setting TDT delay to %s' % delay)
+        if delay_trig is not None:
+            self.rpcox.SetTagVal('trigdel', delay_trig)
+            logger.info('Expyfun: Setting TDT trigger delay to %s'
+                        % delay_trig)
 
 # ############################### TRIGGER METHODS #############################
     def stamp_triggers(self, triggers, delay=0.03, wait_for_last=True):

--- a/expyfun/_tdt_controller.py
+++ b/expyfun/_tdt_controller.py
@@ -244,18 +244,15 @@ class TDTController(Keyboard):
         self._trigger(5)
         logger.debug('Expyfun: Resetting TDT ring buffer')
 
-    def _set_delay(self, delay=None, delay_trig=None):
+    def _set_delay(self, delay, delay_trig):
         """Set the delay (in ms) of the system
         """
         assert isinstance(delay, int)  # this should never happen
         assert isinstance(delay_trig, int)
-        if delay is not None:
-            self.rpcox.SetTagVal('onsetdel', delay)
-            logger.info('Expyfun: Setting TDT delay to %s' % delay)
-        if delay_trig is not None:
-            self.rpcox.SetTagVal('trigdel', delay_trig)
-            logger.info('Expyfun: Setting TDT trigger delay to %s'
-                        % delay_trig)
+        self.rpcox.SetTagVal('onsetdel', delay)
+        logger.info('Expyfun: Setting TDT delay to %s' % delay)
+        self.rpcox.SetTagVal('trigdel', delay_trig)
+        logger.info('Expyfun: Setting TDT trigger delay to %s' % delay_trig)
 
 # ############################### TRIGGER METHODS #############################
     def stamp_triggers(self, triggers, delay=0.03, wait_for_last=True):

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -413,9 +413,14 @@ def test_tdt_delay():
     with ExperimentController(*std_args, tdt_delay=None,
                               audio_controller='tdt', **std_kwargs) as ec:
         ec.wait_secs(0)
+    warnings.simplefilter('ignore')  # This should throw a warning. Ignore it.
+    with ExperimentController(*std_args, tdt_delay=None,
+                              audio_controller='pyglet', **std_kwargs) as ec:
+        ec.wait_secs(0)
+    warnings.simplefilter('always')
     assert_raises(TypeError, ExperimentController, *std_args, tdt_delay='foo',
                   audio_controller='tdt', **std_kwargs)
-    assert_raises(ValueError, ExperimentController, *std_args,
+    assert_raises(OverflowError, ExperimentController, *std_args,
                   tdt_delay=np.inf, audio_controller='tdt', **std_kwargs)
     assert_raises(TypeError, ExperimentController, *std_args,
                   tdt_delay=np.ones(2), audio_controller='tdt', **std_kwargs)

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -415,8 +415,8 @@ def test_tdt_delay():
         ec.wait_secs(0)
     assert_raises(TypeError, ExperimentController, *std_args, tdt_delay='foo',
                   audio_controller='tdt', **std_kwargs)
-    assert_raises(ValueError, ExperimentController, *std_args, tdt_delay=np.inf,
-                  audio_controller='tdt', **std_kwargs)
+    assert_raises(ValueError, ExperimentController, *std_args,
+                  tdt_delay=np.inf, audio_controller='tdt', **std_kwargs)
     assert_raises(TypeError, ExperimentController, *std_args,
                   tdt_delay=np.ones(2), audio_controller='tdt', **std_kwargs)
     assert_raises(ValueError, ExperimentController, *std_args, tdt_delay=-1,

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -404,17 +404,20 @@ def test_background_color():
 @_hide_window
 def test_tdt_delay():
     """test the tdt_delay parameter"""
-    with ExperimentController(*std_args, tdt_delay=0, **std_kwargs) as ec:
+    with ExperimentController(*std_args, tdt_delay=0, audio_controller='tdt',
+                              **std_kwargs) as ec:
         ec.wait_secs(0)  # so pyflakes doesn't whine about not using ec
-    with ExperimentController(*std_args, tdt_delay=1, **std_kwargs) as ec:
+    with ExperimentController(*std_args, tdt_delay=1, audio_controller='tdt',
+                              **std_kwargs) as ec:
         ec.wait_secs(0)
-    with ExperimentController(*std_args, tdt_delay=None, **std_kwargs) as ec:
+    with ExperimentController(*std_args, tdt_delay=None,
+                              audio_controller='tdt', **std_kwargs) as ec:
         ec.wait_secs(0)
     assert_raises(TypeError, ExperimentController, *std_args, tdt_delay='foo',
-                  **std_kwargs)
-    assert_raises(TypeError, ExperimentController, *std_args, tdt_delay=np.inf,
-                  **std_kwargs)
+                  audio_controller='tdt', **std_kwargs)
+    assert_raises(ValueError, ExperimentController, *std_args, tdt_delay=np.inf,
+                  audio_controller='tdt', **std_kwargs)
     assert_raises(TypeError, ExperimentController, *std_args,
-                  tdt_delay=np.ones(2), **std_kwargs)
+                  tdt_delay=np.ones(2), audio_controller='tdt', **std_kwargs)
     assert_raises(ValueError, ExperimentController, *std_args, tdt_delay=-1,
-                  **std_kwargs)
+                  audio_controller='tdt', **std_kwargs)

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -399,3 +399,22 @@ def test_background_color():
         black_mask = (ss == [0] * 3)
         assert_true(black_mask.any())
         assert_true(np.logical_or(gray_mask, black_mask).all())
+
+
+@_hide_window
+def test_tdt_delay():
+    """test the tdt_delay parameter"""
+    with ExperimentController(*std_args, tdt_delay=0, **std_kwargs) as ec:
+        ec.wait_secs(0)  # so pyflakes doesn't whine about not using ec
+    with ExperimentController(*std_args, tdt_delay=1, **std_kwargs) as ec:
+        ec.wait_secs(0)
+    with ExperimentController(*std_args, tdt_delay=None, **std_kwargs) as ec:
+        ec.wait_secs(0)
+    assert_raises(TypeError, ExperimentController, *std_args, tdt_delay='foo',
+                  **std_kwargs)
+    assert_raises(TypeError, ExperimentController, *std_args, tdt_delay=np.inf,
+                  **std_kwargs)
+    assert_raises(TypeError, ExperimentController, *std_args,
+                  tdt_delay=np.ones(2), **std_kwargs)
+    assert_raises(ValueError, ExperimentController, *std_args, tdt_delay=-1,
+                  **std_kwargs)


### PR DESCRIPTION
We have a TDT_DELAY parameter for delaying the audio and triggers so that the audio and video line up. If you want to present stimuli rapidly and you don't care about AV sync, this is a problem where that delay is large (as it is on the MEG computer). This allows you to set it.

NB: well after I spent a bunch of time on this, I realized this could be done by passing a dict as `audio_controller` when instantiating `ExperimentController`. I decided to finish it because it has two advantages: input type and value checking, and not requiring the TDT to be used, making development on your own computer easier.