### PR TITLE
MRG: Dont mangle env during setup

### DIFF
--- a/expyfun/_git.py
+++ b/expyfun/_git.py
@@ -83,7 +83,12 @@ def download_version(version='current', dest_dir=None):
     orig_stdout = sys.stdout
     try:
         from setup import git_version, setup_package
-        assert git_version()[0].lower() == version[:7].lower()
+        version = git_version()
+        # This is necessary because for a while git_version returned
+        # a tuple of (version, fork)
+        if not isinstance(version, string_types):
+            version = version[0]
+        assert version.lower() == version[:7].lower()
         sys.stdout = StringIO()
         with warnings.catch_warnings(record=True):  # PEP440
             setup_package(script_args=['build', '--build-purelib', dest_dir])

--- a/expyfun/_git.py
+++ b/expyfun/_git.py
@@ -10,12 +10,6 @@ from ._version import __version__
 this_version = __version__[-7:]
 
 try:
-    from ._version import __fork__
-    this_fork = __fork__
-except ImportError:
-    this_fork = None
-
-try:
     run_subprocess(['git', '--help'])
 except Exception as exp:
     _has_git, why_not = False, str(exp)
@@ -41,7 +35,7 @@ def _active_version(wd):
     return run_subprocess(['git', 'rev-parse', 'HEAD'], cwd=wd)[0][:7]
 
 
-def download_version(version='current', dest_dir=None, fork='LABSN'):
+def download_version(version='current', dest_dir=None):
     """Download specific expyfun version
 
     Parameters
@@ -53,8 +47,6 @@ def download_version(version='current', dest_dir=None, fork='LABSN'):
     dest_dir : str | None
         Destination directory. If None, the current working
         directory is used.
-    fork : str
-        GitHub username of the expyfun fork to download from.
 
     Notes
     -----
@@ -74,7 +66,7 @@ def download_version(version='current', dest_dir=None, fork='LABSN'):
     # fetch locally and get the proper version
     tempdir = _TempDir()
     expyfun_dir = op.join(tempdir, 'expyfun')  # git will auto-create this dir
-    repo_url = 'git://github.com/{}/expyfun.git'.format(fork)
+    repo_url = 'git://github.com/LABSN/expyfun.git'
     run_subprocess(['git', 'clone', repo_url, expyfun_dir])
     version = _active_version(expyfun_dir) if version == 'current' else version
     try:
@@ -100,7 +92,6 @@ def download_version(version='current', dest_dir=None, fork='LABSN'):
         sys.path.pop(sys.path.index(expyfun_dir))
         os.chdir(orig_dir)
     print('\n'.join(['Successfully checked out expyfun version:', version,
-                     'from the "{}" fork of expyfun'.format(fork),
                      'into destination directory:', op.join(dest_dir)]))
 
 
@@ -113,11 +104,6 @@ def assert_version(version):
         Version to check (7 characters).
     """
     _check_version_format(version)
-    if this_fork is not None and this_fork.lower() != 'labsn':
-        warnings.warn('You are running a forked version of the expyfun '
-                      'codebase (fork "{}"). Do not do this if you are '
-                      'running an actual experiment; only do this during '
-                      'development.'.format(this_fork), RuntimeWarning)
     if this_version.lower() != version.lower():
         raise AssertionError('Requested version {0} does not match current '
                              'version {1}'.format(version, this_version))

--- a/expyfun/_version.py
+++ b/expyfun/_version.py
@@ -1,2 +1,1 @@
 __version__ = '2.0.0.dev0'
-__fork__ = 'rkmaddox'

--- a/expyfun/tests/test_version.py
+++ b/expyfun/tests/test_version.py
@@ -25,21 +25,18 @@ def test_version():
     assert_true(all('actual' in str(ww.message) for ww in w))
 
     v = 'b798e65'
-    f = 'drammock'
     if not _has_git:
-        assert_raises(ImportError, download_version, v, tempdir, f)
+        assert_raises(ImportError, download_version, v, tempdir)
     else:
-        assert_raises(IOError, download_version, v, op.join(tempdir, 'foo'), f)
-        assert_raises(RuntimeError, download_version, 'x' * 7, tempdir, f)
-        download_version(v, tempdir, f)
+        assert_raises(IOError, download_version, v, op.join(tempdir, 'foo'))
+        assert_raises(RuntimeError, download_version, 'x' * 7, tempdir)
+        download_version(v, tempdir)
         ex_dir = op.join(tempdir, 'expyfun')
         assert_true(op.isdir(ex_dir))
         assert_true(op.isfile(op.join(ex_dir, '__init__.py')))
         with open(op.join(ex_dir, '_version.py')) as fid:
             line1 = fid.readline().strip()
-            line2 = fid.readline().strip()
         assert_equal(line1.split(' = ')[1][-8:-1], v)
-        assert_equal(line2.split(' = ')[1].strip('\''), f)
 
         # auto dir determination
         orig_dir = os.getcwd()

--- a/expyfun/tests/test_version.py
+++ b/expyfun/tests/test_version.py
@@ -24,7 +24,7 @@ def test_version():
         assert_version(__version__[-7:])
     assert_true(all('actual' in str(ww.message) for ww in w))
 
-    v = 'b798e65'
+    v = '090948e'
     if not _has_git:
         assert_raises(ImportError, download_version, v, tempdir)
     else:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def git_version():
         # minimal env; LANGUAGE is used on win32
         return subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                 ).communicate()[0]
-    GIT_REVISION = "Unknown"
+    GIT_REVISION = 'Unknown'
     if os.path.exists('.git'):
         try:
             out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
@@ -97,5 +97,5 @@ def setup_package(script_args=None):
         write_version(VERSION)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     setup_package()

--- a/setup.py
+++ b/setup.py
@@ -31,19 +31,16 @@ def git_version():
     """Helper adapted from Numpy"""
     def _minimal_ext_cmd(cmd):
         # minimal env; LANGUAGE is used on win32
-        env = dict(LANGUAGE='C', LANG='C', LC_ALL='C')
-        for k in ['SYSTEMROOT', 'PATH']:
-            v = os.environ.get(k)
-            if v is not None:
-                env[k] = v
         return subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                env=env).communicate()[0]
+                                ).communicate()[0]
+    GIT_REVISION = "Unknown"
+    FORK = "Unknown"
     if os.path.exists('.git'):
         try:
             out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
             GIT_REVISION = out.decode('utf-8').strip()
         except OSError:
-            GIT_REVISION = "Unknown"
+            pass
         try:
             cmd = ['git', 'config', '--get', 'remote.origin.url']
             out = _minimal_ext_cmd(cmd).decode('utf-8').strip()
@@ -56,10 +53,7 @@ def git_version():
             if start_idx:
                 FORK = out[start_idx:out.rindex('/')]
         except OSError:
-            FORK = 'Unknown'
-    else:
-        GIT_REVISION = "Unknown"
-        FORK = 'Unknown'
+            pass
     return [GIT_REVISION[:7], FORK]
 
 FULL_VERSION = VERSION + '+' + git_version()[0]

--- a/setup.py
+++ b/setup.py
@@ -34,36 +34,20 @@ def git_version():
         return subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                 ).communicate()[0]
     GIT_REVISION = "Unknown"
-    FORK = "Unknown"
     if os.path.exists('.git'):
         try:
             out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
             GIT_REVISION = out.decode('utf-8').strip()
         except OSError:
             pass
-        try:
-            cmd = ['git', 'config', '--get', 'remote.origin.url']
-            out = _minimal_ext_cmd(cmd).decode('utf-8').strip()
-            start_idx = 0
-            for prefix in ['git@github.com:', 'git://github.com/',
-                           'http://github.com/', 'https://github.com/',
-                           'ssh://git@github.com/']:
-                if out.startswith(prefix):
-                    start_idx = len(prefix)
-            if start_idx:
-                FORK = out[start_idx:out.rindex('/')]
-        except OSError:
-            pass
-    return [GIT_REVISION[:7], FORK]
+    return GIT_REVISION[:7]
 
 FULL_VERSION = VERSION + '+' + git_version()[0]
-FORK = git_version()[1]
 
 
-def write_version(version, fork='Unknown'):
+def write_version(version):
     with open(version_file, 'w') as fid:
         fid.write('__version__ = \'{0}\'\n'.format(version))
-        fid.write('__fork__ = \'{0}\'\n'.format(fork))
 
 
 def setup_package(script_args=None):
@@ -107,10 +91,10 @@ def setup_package(script_args=None):
     if script_args is not None:
         kwargs['script_args'] = script_args
     try:
-        write_version(FULL_VERSION, FORK)
+        write_version(FULL_VERSION)
         setup(**kwargs)
     finally:
-        write_version(VERSION, FORK)
+        write_version(VERSION)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@drammock on OSX setting the `env` during `setup.py` can break things because it makes `git` no longer available. I think you set at least some of this up -- think it's reasonable?

Closes #271.
Closes #305.