### PR TITLE
WIP: Eyelink origin discrepancy

### DIFF
--- a/expyfun/_eyelink_controller.py
+++ b/expyfun/_eyelink_controller.py
@@ -603,7 +603,6 @@ class EyelinkController(object):
                 eye_pos = np.array(sample.getRightEye().getGaze())
             else:
                 eye_pos = np.array([np.inf, np.inf])
-            eye_pos -= (self._size / 2.)
         else:
             # use mouse, already referenced to center
             eye_pos = self._ec.get_mouse_position()


### PR DESCRIPTION
(copied from issue description) After setting up the eyelink I noticed that there was a discrepancy between coordinate systems.

`el.get_eye_position()` returns location in pixels with the center of the screen being `[0, 0]`. The eyelink itself claims to output a location where the top left is `[0, 0]` (but it seems more like it's using the bottom left). `ec._convert_units()`, however, assumes that the pixel locations use the bottom left of the screen as `[0, 0]`.

Since `el.wait_for_fix()` uses both `el.get_eye_position()` and `ec._convert_units()`, the coordinates never match up.