### PR TITLE
MRG: Fix version

### DIFF
--- a/expyfun/_git.py
+++ b/expyfun/_git.py
@@ -83,6 +83,10 @@ def download_version(version='current', dest_dir=None):
     sys.path.insert(0, expyfun_dir)
     orig_stdout = sys.stdout
     try:
+        try:
+            from importlib import reload
+        except ImportError:
+            pass  # Python2.7
         import setup
         reload(setup)
         setup_version = setup.git_version()

--- a/expyfun/_git.py
+++ b/expyfun/_git.py
@@ -100,7 +100,6 @@ def download_version(version='current', dest_dir=None):
         sys.stdout = orig_stdout
         sys.path.pop(sys.path.index(expyfun_dir))
         os.chdir(orig_dir)
-    # check our round-trip
     print('\n'.join(['Successfully checked out expyfun version:', version,
                      'into destination directory:', op.join(dest_dir)]))
 

--- a/expyfun/_git.py
+++ b/expyfun/_git.py
@@ -4,7 +4,7 @@ from os import path as op
 import sys
 import warnings
 
-from ._utils import _TempDir, string_types, run_subprocess, StringIO
+from ._utils import _TempDir, string_types, run_subprocess, StringIO, reload
 from ._version import __version__
 
 this_version = __version__[-7:]
@@ -83,10 +83,6 @@ def download_version(version='current', dest_dir=None):
     sys.path.insert(0, expyfun_dir)
     orig_stdout = sys.stdout
     try:
-        try:
-            from importlib import reload
-        except ImportError:
-            pass  # Python2.7
         import setup
         reload(setup)
         setup_version = setup.git_version()

--- a/expyfun/_git.py
+++ b/expyfun/_git.py
@@ -90,6 +90,7 @@ def download_version(version='current', dest_dir=None):
             version = version[0]
         assert version.lower() == version[:7].lower()
         sys.stdout = StringIO()
+        print(dest_dir)
         with warnings.catch_warnings(record=True):  # PEP440
             setup_package(script_args=['build', '--build-purelib', dest_dir])
     finally:

--- a/expyfun/_git.py
+++ b/expyfun/_git.py
@@ -79,24 +79,28 @@ def download_version(version='current', dest_dir=None):
     # install
     orig_dir = os.getcwd()
     os.chdir(expyfun_dir)
-    sys.path.insert(0, expyfun_dir)  # ensure our new "setup" is imported
+    # ensure our version-specific "setup" is imported
+    sys.path.insert(0, expyfun_dir)
     orig_stdout = sys.stdout
     try:
-        from setup import git_version, setup_package
-        version = git_version()
+        import setup
+        reload(setup)
+        setup_version = setup.git_version()
         # This is necessary because for a while git_version returned
         # a tuple of (version, fork)
-        if not isinstance(version, string_types):
-            version = version[0]
-        assert version.lower() == version[:7].lower()
+        if not isinstance(setup_version, string_types):
+            setup_version = setup_version[0]
+        assert version.lower() == setup_version[:7].lower()
+        del setup_version
         sys.stdout = StringIO()
-        print(dest_dir)
         with warnings.catch_warnings(record=True):  # PEP440
-            setup_package(script_args=['build', '--build-purelib', dest_dir])
+            setup.setup_package(
+                script_args=['build', '--build-purelib', dest_dir])
     finally:
         sys.stdout = orig_stdout
         sys.path.pop(sys.path.index(expyfun_dir))
         os.chdir(orig_dir)
+    # check our round-trip
     print('\n'.join(['Successfully checked out expyfun version:', version,
                      'into destination directory:', op.join(dest_dir)]))
 

--- a/expyfun/_utils.py
+++ b/expyfun/_utils.py
@@ -44,6 +44,7 @@ if sys.version.startswith('2'):
     string_types = basestring  # noqa
     input = raw_input  # noqa, input is raw_input in py3k
     text_type = unicode  # noqa
+    from __builtin__ import reload
     from urllib2 import urlopen  # noqa
     from cStringIO import StringIO  # noqa
 else:
@@ -52,6 +53,7 @@ else:
     from urllib.request import urlopen
     input = input
     from io import StringIO  # noqa, analysis:ignore
+    from importlib import reload  # noqa, analysis:ignore
 
 ###############################################################################
 # LOGGING

--- a/expyfun/tests/test_version.py
+++ b/expyfun/tests/test_version.py
@@ -2,6 +2,7 @@
 import os
 from os import path as op
 import warnings
+import shutil
 
 from nose.tools import assert_raises, assert_true, assert_equal
 
@@ -9,9 +10,6 @@ from expyfun import (ExperimentController, assert_version, download_version,
                      __version__)
 from expyfun._utils import _TempDir
 from expyfun._git import _has_git
-
-tempdir = _TempDir()
-tempdir_2 = _TempDir()
 
 
 def test_version():
@@ -24,35 +22,42 @@ def test_version():
         assert_version(__version__[-7:])
     assert_true(all('actual' in str(ww.message) for ww in w))
 
-    v = '090948e'
-    if not _has_git:
-        assert_raises(ImportError, download_version, v, tempdir)
-    else:
-        assert_raises(IOError, download_version, v, op.join(tempdir, 'foo'))
-        assert_raises(RuntimeError, download_version, 'x' * 7, tempdir)
-        download_version(v, tempdir)
-        ex_dir = op.join(tempdir, 'expyfun')
-        assert_true(op.isdir(ex_dir))
-        assert_true(op.isfile(op.join(ex_dir, '__init__.py')))
-        with open(op.join(ex_dir, '_version.py')) as fid:
-            line1 = fid.readline().strip()
-        assert_equal(line1.split(' = ')[1][-8:-1], v)
+    for want_version in ('cae6bc3', '090948e'):  # old, new
+        tempdir = _TempDir()
+        tempdir_2 = _TempDir()
+        if not _has_git:
+            assert_raises(ImportError, download_version, want_version, tempdir)
+        else:
+            assert_raises(IOError, download_version, want_version,
+                          op.join(tempdir, 'foo'))
+            assert_raises(RuntimeError, download_version, 'x' * 7, tempdir)
+            download_version(want_version, tempdir)
+            ex_dir = op.join(tempdir, 'expyfun')
+            assert_true(op.isdir(ex_dir))
+            assert_true(op.isfile(op.join(ex_dir, '__init__.py')))
+            with open(op.join(ex_dir, '_version.py')) as fid:
+                line1 = fid.readline().strip()
+            if want_version == 'cae6bc3':
+                assert_equal(line1.split(' = ')[1][-8:-1], '.dev0+c')
+            else:
+                assert_equal(line1.split(' = ')[1][-8:-1], want_version)
 
-        # auto dir determination
-        orig_dir = os.getcwd()
-        os.chdir(tempdir)
-        try:
-            assert_true(op.isdir('expyfun'))
-            assert_raises(IOError, download_version, v)
-        finally:
-            os.chdir(orig_dir)
-        # make sure we can get latest version
-        download_version(dest_dir=tempdir_2)
+            # auto dir determination
+            orig_dir = os.getcwd()
+            os.chdir(tempdir)
+            try:
+                assert_true(op.isdir('expyfun'))
+                assert_raises(IOError, download_version, want_version)
+            finally:
+                os.chdir(orig_dir)
+            # make sure we can get latest version
+            assert_raises(IOError, download_version, dest_dir=tempdir)
+            download_version(dest_dir=tempdir_2)
 
 
 def test_integrated_version_checking():
-    """Test EC version checking during init
-    """
+    """Test EC version checking during init."""
+    tempdir = _TempDir()
     args = ['test']  # experiment name
     kwargs = dict(output_dir=tempdir, full_screen=False, window_size=(1, 1),
                   participant='foo', session='01', stim_db=0.0, noise_db=0.0,

--- a/expyfun/tests/test_version.py
+++ b/expyfun/tests/test_version.py
@@ -23,7 +23,6 @@ def test_version():
 
     for want_version in ('090948e', 'cae6bc3', 'b6e8a81'):  # old, broken, new
         tempdir = _TempDir()
-        tempdir_2 = _TempDir()
         if not _has_git:
             assert_raises(ImportError, download_version, want_version, tempdir)
         else:
@@ -52,9 +51,11 @@ def test_version():
                 assert_raises(IOError, download_version, want_version)
             finally:
                 os.chdir(orig_dir)
-            # make sure we can get latest version
-            assert_raises(IOError, download_version, dest_dir=tempdir)
-            download_version(dest_dir=tempdir_2)
+    # make sure we can get latest version
+    tempdir_2 = _TempDir()
+    if _has_git:
+        assert_raises(IOError, download_version, dest_dir=tempdir)
+        download_version(dest_dir=tempdir_2)
 
 
 def test_integrated_version_checking():

--- a/expyfun/tests/test_version.py
+++ b/expyfun/tests/test_version.py
@@ -40,8 +40,9 @@ def test_version():
                 line1 = fid.readline().strip()
             got_version = line1.split(' = ')[1][-8:-1]
             ex = want_version if want_version != 'cae6bc3' else '.dev0+c'
-            assert_equal(got_version, ex, msg='File %s: %s != %s'
-                         % (got_fname, got_version, ex))
+            assert_equal(got_version, ex,
+                         msg='File {0}: {1} != {2}'.format(got_fname,
+                                                           got_version, ex))
 
             # auto dir determination
             orig_dir = os.getcwd()

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ def git_version():
             pass
     return GIT_REVISION[:7]
 
-FULL_VERSION = VERSION + '+' + git_version()[0]
+
+FULL_VERSION = VERSION + '+' + git_version()
 
 
 def write_version(version):


### PR DESCRIPTION
Our current version code returns junk like `.dev0+c` so version assertion round-trips fail. This fixes the problem (there was a lingering `[0]` in `setup.py`)