### PR TITLE
MRG: Fix tracker stopping

### DIFF
--- a/expyfun/stimuli/_tracker.py
+++ b/expyfun/stimuli/_tracker.py
@@ -322,9 +322,9 @@ class TrackerUD(object):
         return self._valid
 
     def _stop_here(self):
-        if self._n_reversals > self._stop_reversals:
+        if self._n_reversals == self._stop_reversals:
             self._n_stop = True
-        elif self._n_trials > self._stop_trials:
+        elif self._n_trials == self._stop_trials:
             self._n_stop = True
         else:
             self._n_stop = False

--- a/expyfun/stimuli/tests/test_tracker.py
+++ b/expyfun/stimuli/tests/test_tracker.py
@@ -3,7 +3,7 @@ import matplotlib
 matplotlib.use('Agg')  # noqa
 from expyfun.stimuli import TrackerUD, TrackerBinom, TrackerDealer
 from expyfun import ExperimentController
-from nose.tools import assert_raises, assert_equal, assert_true
+from nose.tools import assert_raises, assert_equal
 from expyfun._utils import _hide_window, requires_opengl21
 import warnings
 
@@ -31,7 +31,7 @@ def test_tracker_ud():
     rand = np.random.RandomState(0)
     while not tr.stopped:
         tr.respond(rand.rand() < tr.x_current)
-    assert_true(tr.n_reversals == tr.stop_reversals)
+    assert_equal(tr.n_reversals, tr.stop_reversals)
 
     tr = TrackerUD(None, 3, 1, 1, 1, np.inf, 10, 1)
     tr.threshold()
@@ -87,7 +87,7 @@ def test_tracker_ud():
     assert(not tr.check_valid(3))
     assert_raises(ValueError, tr.threshold, 1)
     tr.threshold(3)
-    assert_true(tr.n_trials == tr.stop_trials)
+    assert_equal(tr.n_trials, tr.stop_trials)
 
     # run tests with ignore too--should generate warnings, but no error
     with warnings.catch_warnings(record=True) as w:

--- a/expyfun/stimuli/tests/test_tracker.py
+++ b/expyfun/stimuli/tests/test_tracker.py
@@ -3,7 +3,7 @@ import matplotlib
 matplotlib.use('Agg')  # noqa
 from expyfun.stimuli import TrackerUD, TrackerBinom, TrackerDealer
 from expyfun import ExperimentController
-from nose.tools import assert_raises, assert_equal
+from nose.tools import assert_raises, assert_equal, assert_true
 from expyfun._utils import _hide_window, requires_opengl21
 import warnings
 
@@ -27,10 +27,11 @@ def test_tracker_ud():
     tr = TrackerUD(callback, 3, 1, 1, 1, np.inf, 10, 1)
     with ExperimentController('test', **std_kwargs) as ec:
         tr = TrackerUD(ec, 3, 1, 1, 1, np.inf, 10, 1)
-    tr = TrackerUD(None, 3, 1, 1, 1, np.inf, 10, 1)
+    tr = TrackerUD(None, 3, 1, 1, 1, 10, np.inf, 1)
     rand = np.random.RandomState(0)
     while not tr.stopped:
         tr.respond(rand.rand() < tr.x_current)
+    assert_true(tr.n_reversals==tr.stop_reversals)
 
     tr = TrackerUD(None, 3, 1, 1, 1, np.inf, 10, 1)
     tr.threshold()
@@ -86,6 +87,7 @@ def test_tracker_ud():
     assert(not tr.check_valid(3))
     assert_raises(ValueError, tr.threshold, 1)
     tr.threshold(3)
+    assert_true(tr.n_trials==tr.stop_trials)
 
     # run tests with ignore too--should generate warnings, but no error
     with warnings.catch_warnings(record=True) as w:

--- a/expyfun/stimuli/tests/test_tracker.py
+++ b/expyfun/stimuli/tests/test_tracker.py
@@ -76,7 +76,7 @@ def test_tracker_ud():
     tr.respond(True)
 
     with warnings.catch_warnings(record=True) as w:
-        tr = TrackerUD(None, 1, 1, 0.75, 0.75, np.inf, 8, 1,
+        tr = TrackerUD(None, 1, 1, 0.75, 0.75, np.inf, 9, 1,
                        x_min=0, x_max=2)
         responses = [True, True, True, False, False, False, False, True, False]
         for r in responses:  # run long enough to encounter change_indices
@@ -89,7 +89,7 @@ def test_tracker_ud():
 
     # run tests with ignore too--should generate warnings, but no error
     with warnings.catch_warnings(record=True) as w:
-        tr = TrackerUD(None, 1, 1, 0.75, 0.25, np.inf, 7, 1,
+        tr = TrackerUD(None, 1, 1, 0.75, 0.25, np.inf, 8, 1,
                        x_min=0, x_max=2, repeat_limit='ignore')
         responses = [False, True, False, False, True, True, False, True]
         for r in responses:  # run long enough to encounter change_indices

--- a/expyfun/stimuli/tests/test_tracker.py
+++ b/expyfun/stimuli/tests/test_tracker.py
@@ -31,7 +31,7 @@ def test_tracker_ud():
     rand = np.random.RandomState(0)
     while not tr.stopped:
         tr.respond(rand.rand() < tr.x_current)
-    assert_true(tr.n_reversals==tr.stop_reversals)
+    assert_true(tr.n_reversals == tr.stop_reversals)
 
     tr = TrackerUD(None, 3, 1, 1, 1, np.inf, 10, 1)
     tr.threshold()
@@ -87,7 +87,7 @@ def test_tracker_ud():
     assert(not tr.check_valid(3))
     assert_raises(ValueError, tr.threshold, 1)
     tr.threshold(3)
-    assert_true(tr.n_trials==tr.stop_trials)
+    assert_true(tr.n_trials == tr.stop_trials)
 
     # run tests with ignore too--should generate warnings, but no error
     with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
Issue with tracker stopping at ``stop_trials + 1`` or ``stop_reversals + 1`` rather than at the actual stopping criteria.