### PR TITLE
MRG: Add calibration schemes to eyetracker

### DIFF
--- a/expyfun/_eyelink_controller.py
+++ b/expyfun/_eyelink_controller.py
@@ -535,7 +535,8 @@ class EyelinkController(object):
         Parameters
         ----------
         ctype : str
-            Type of calibration. Currently only 'HV5' is supported.
+            Type of calibration. Currently 'H3', 'HV5', 'HV9', and 'HV13'
+            are supported.
         horiz : float
             Horizontal distance (left and right, each) to use.
         vert : float
@@ -547,7 +548,7 @@ class EyelinkController(object):
         --------
         EyelinkController.calibrate
         """
-        allowed_types = ['HV5', 'HV9', 'H3', 'HV13']
+        allowed_types = ['H3', 'HV5', 'HV9', 'HV13']
         if ctype not in allowed_types:
             raise ValueError('ctype cannot be "{0}", but must be one of {1}'
                              ''.format(ctype, allowed_types))

--- a/expyfun/_eyelink_controller.py
+++ b/expyfun/_eyelink_controller.py
@@ -547,7 +547,7 @@ class EyelinkController(object):
         --------
         EyelinkController.calibrate
         """
-        allowed_types = ['HV5', 'HV9', 'H3']
+        allowed_types = ['HV5', 'HV9', 'H3', 'HV13']
         if ctype not in allowed_types:
             raise ValueError('ctype cannot be "{0}", but must be one of {1}'
                              ''.format(ctype, allowed_types))
@@ -568,6 +568,10 @@ class EyelinkController(object):
                             [-1, -1], [1, -1], [-1, 1]])
         elif ctype == 'H3':
             mat = np.array([[0, 0], [1, 0], [-1, 0]])
+        elif ctype == 'HV13':
+            mat = np.array([[0, 0], [1, 0], [-1, 0], [0, 1], [0, -1], [1, 1],
+                            [-1, -1], [1, -1], [-1, 1], [.5, .5], [-.5, -.5],
+                            [.5, -.5], [-.5, .5]])
         offsets = mat * np.array([h_pix, v_pix])
         coords = (self._size / 2. + offsets)
         n_samples = coords.shape[0]

--- a/expyfun/_eyelink_controller.py
+++ b/expyfun/_eyelink_controller.py
@@ -547,7 +547,7 @@ class EyelinkController(object):
         --------
         EyelinkController.calibrate
         """
-        allowed_types = ['HV5']
+        allowed_types = ['HV5', 'HV9', 'H3']
         if ctype not in allowed_types:
             raise ValueError('ctype cannot be "{0}", but must be one of {1}'
                              ''.format(ctype, allowed_types))
@@ -561,7 +561,13 @@ class EyelinkController(object):
                 raise ValueError('{0} too large ({1} > {2})'
                                  ''.format(s, p, m))
         # make the locations
-        mat = np.array([[0, 0], [1, 0], [-1, 0], [0, 1], [0, -1]])
+        if ctype == 'HV5':
+            mat = np.array([[0, 0], [1, 0], [-1, 0], [0, 1], [0, -1]])
+        elif ctype == 'HV9':
+            mat = np.array([[0, 0], [1, 0], [-1, 0], [0, 1], [0, -1], [1, 1],
+                            [-1, -1], [1, -1], [-1, 1]])
+        elif ctype == 'H3':
+            mat = np.array([[0, 0], [1, 0], [-1, 0]])
         offsets = mat * np.array([h_pix, v_pix])
         coords = (self._size / 2. + offsets)
         n_samples = coords.shape[0]

--- a/expyfun/tests/test_eyelink_controller.py
+++ b/expyfun/tests/test_eyelink_controller.py
@@ -21,7 +21,9 @@ def test_eyelink_methods():
         el = EyelinkController(ec)
         assert_raises(RuntimeError, EyelinkController, ec)  # can't have 2 open
         assert_raises(ValueError, el.custom_calibration, ctype='hey')
-        el.custom_calibration()
+        el.custom_calibration('H3')
+        el.custom_calibration('HV9')
+        el.custom_calibration('HV13')
         el._open_file()
         assert_raises(RuntimeError, el._open_file)
         el._start_recording()


### PR DESCRIPTION
We ran into issues with the HV5 calibration scheme for the eyetracker and wanted to test out some other options (HV9 and H3 so far). 

I'd also like to add HV13 if possible but am not sure what those target coordinates actually are--based on the icon in the eyelink settings window they aren't quite an even grid and I'm still trying to figure those numbers out.

Disclaimer: I'm working on the computer that's actually attached to the eyelink system so all commits will come from rkmaddox for this PR but they are from me. My apologies!