### PR TITLE
FIX: Eyelink not able to get position for right eye

### DIFF
--- a/expyfun/_eyelink_controller.py
+++ b/expyfun/_eyelink_controller.py
@@ -597,9 +597,9 @@ class EyelinkController(object):
             if sample.isBinocular():
                 eye_pos = (np.array(sample.getLeftEye().getGaze()) +
                            np.array(sample.getRightEye().getGaze())) / 2.
-            elif sample.isLeftSample:
+            elif sample.isLeftSample():
                 eye_pos = np.array(sample.getLeftEye().getGaze())
-            elif sample.isRightSample:
+            elif sample.isRightSample():
                 eye_pos = np.array(sample.getRightEye().getGaze())
             else:
                 eye_pos = np.array([np.inf, np.inf])


### PR DESCRIPTION
We have not been able to use the right eye for any tracking until I found what looks to be missing parentheses.

Is this just a fix for us?