### PR TITLE
MRG: advance from screen_prompt with click

### DIFF
--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -442,9 +442,9 @@ class ExperimentController(object):
         return scr_txt
 
     def screen_prompt(self, text, max_wait=np.inf, min_wait=0, live_keys=None,
-                      timestamp=False, clear_after=True, pos=[0, 0],
-                      color='white', font_name='Arial', font_size=24,
-                      wrap=True, units='norm', attr=True):
+                      click=False, timestamp=False, clear_after=True,
+                      pos=[0, 0], color='white', font_name='Arial',
+                      font_size=24, wrap=True, units='norm', attr=True):
         """Display text and (optionally) wait for user continuation
 
         Parameters
@@ -462,6 +462,8 @@ class ExperimentController(object):
             The acceptable list of buttons or keys to use to advance the trial.
             If None, all buttons / keys will be accepted.  If an empty list,
             the prompt displays until max_wait seconds have passed.
+        click : bool
+            Whether to use clicks to advance rather than key presses.
         clear_after : bool
             If True, the screen will be cleared before returning.
         pos : list | tuple
@@ -507,8 +509,12 @@ class ExperimentController(object):
                              font_size=font_size, wrap=wrap, units=units,
                              attr=attr)
             self.flip()
-            out = self.wait_one_press(max_wait, min_wait, live_keys,
-                                      timestamp)
+            if click:
+                out = self.wait_one_click(max_wait, min_wait, live_keys,
+                                          timestamp)
+            else:
+                out = self.wait_one_press(max_wait, min_wait, live_keys,
+                                          timestamp)
         if clear_after:
             self.flip()
         return out

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -509,11 +509,8 @@ class ExperimentController(object):
                              font_size=font_size, wrap=wrap, units=units,
                              attr=attr)
             self.flip()
-            if click:
-                out = self.wait_one_click(max_wait, min_wait, live_keys,
-                                          timestamp)
-            else:
-                out = self.wait_one_press(max_wait, min_wait, live_keys,
+            fun = self.wait_one_click if click else self.wait_one_press
+            out = fun(max_wait, min_wait, live_keys,
                                           timestamp)
         if clear_after:
             self.flip()

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -510,8 +510,7 @@ class ExperimentController(object):
                              attr=attr)
             self.flip()
             fun = self.wait_one_click if click else self.wait_one_press
-            out = fun(max_wait, min_wait, live_keys,
-                                          timestamp)
+            out = fun(max_wait, min_wait, live_keys, timestamp)
         if clear_after:
             self.flip()
         return out

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -442,9 +442,9 @@ class ExperimentController(object):
         return scr_txt
 
     def screen_prompt(self, text, max_wait=np.inf, min_wait=0, live_keys=None,
-                      click=False, timestamp=False, clear_after=True,
-                      pos=[0, 0], color='white', font_name='Arial',
-                      font_size=24, wrap=True, units='norm', attr=True):
+                      timestamp=False, clear_after=True, pos=[0, 0],
+                      color='white', font_name='Arial', font_size=24,
+                      wrap=True, units='norm', attr=True, click=False):
         """Display text and (optionally) wait for user continuation
 
         Parameters

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -191,6 +191,7 @@ def test_ec(ac=None, rd=None):
         ec.screen_prompt('test', 0.01, 0, None)
         ec.screen_prompt('test', 0.01, 0, ['1'])
         ec.screen_prompt(['test', 'ing'], 0.01, 0, ['1'])
+        ec.screen_prompt('test', 1e-3, click=True)
         assert_raises(ValueError, ec.screen_prompt, 'foo', np.inf, 0, [])
         assert_raises(TypeError, ec.screen_prompt, 3, 0.01, 0, None)
         assert_equal(ec.wait_one_press(0.01), (None, None))


### PR DESCRIPTION
This just adds a few extra lines in ``ec.screen_prompt`` to allow for subjects to click to advance rather than press a key