### PR TITLE
FIX: Fix recon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ env/
 # Gedit autosave files
 *~
 
+# pytest
+.cache

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # caution: testing won't work on windows, see README
 
 PYTHON ?= python
-NOSETESTS ?= nosetests
+PYTEST ?= pytest
 CTAGS ?= ctags
 
 all: clean inplace test test-doc
@@ -42,12 +42,12 @@ inplace:
 
 nosetests:
 	rm -f .coverage
-	$(NOSETESTS) expyfun
+	$(PYTEST) expyfun
 
 test: clean nosetests flake
 
 test-doc:
-	$(NOSETESTS) --with-doctest --doctest-tests --doctest-extension=rst doc/
+	$(PYTEST) --doctest-modules --doctest-ignore-import-errors --doctest-glob='*.rst' ./doc/
 
 version:
 	@expr substr `git rev-parse HEAD` 1 7

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -738,7 +738,7 @@ class ExperimentController(object):
         data = pyglet.image.get_buffer_manager().get_color_buffer()
         data = self._win.context.image_buffer_manager.color_buffer.image_data
         data = data.get_data(data.format, data.pitch)
-        data = np.fromstring(data, dtype=np.uint8)
+        data = np.frombuffer(data, dtype=np.uint8)
         data.shape = (self._win.height, self._win.width, 4)
         data = np.flipud(data)
         return data

--- a/expyfun/stimuli/_crm.py
+++ b/expyfun/stimuli/_crm.py
@@ -144,7 +144,7 @@ def _read_binary(zip_file, callsign, color, number,
     talk_path = zip_file.filelist[0].orig_filename[:8]
     raw = zip_file.read(talk_path + '/%02i%02i%02i.BIN' % (
         _callsigns[callsign], _colors[color], _numbers[number]))
-    x = np.fromstring(raw, '<h') / 16384.
+    x = np.frombuffer(raw, '<h') / 16384.
     if ramp_dur:
         return window_edges(x, _fs_binary, dur=ramp_dur)
     else:

--- a/expyfun/stimuli/_tracker.py
+++ b/expyfun/stimuli/_tracker.py
@@ -188,12 +188,12 @@ class TrackerUD(object):
         self._limit_count = 0
 
         # Now write the initialization data out
-        self._tracker_id = id(self)
+        self._tracker_id = '%s-%s' % (id(self), int(round(time.time() * 1e6)))
         self._callback('tracker_identify', json.dumps(dict(
             tracker_id=self._tracker_id,
             tracker_type='TrackerUD')))
 
-        self._callback('tracker_%i_init' % self._tracker_id, json.dumps(dict(
+        self._callback('tracker_%s_init' % self._tracker_id, json.dumps(dict(
             callback=None,
             up=self._up,
             down=self._down,
@@ -293,12 +293,12 @@ class TrackerUD(object):
 
         if not self._stopped:
             self._x_current = self._x[-1]
-            self._callback('tracker_%i_respond' % self._tracker_id,
+            self._callback('tracker_%s_respond' % self._tracker_id,
                            correct)
         else:
             self._x = self._x[:-1]
             self._callback(
-                'tracker_%i_stop' % self._tracker_id, json.dumps(dict(
+                'tracker_%s_stop' % self._tracker_id, json.dumps(dict(
                     responses=[int(s) for s in self._responses],
                     reversals=[int(s) for s in self._reversals],
                     x=[float(s) for s in self._x])))
@@ -626,7 +626,7 @@ class TrackerBinom(object):
             tracker_id=self._tracker_id,
             tracker_type='TrackerBinom')))
 
-        self._callback('tracker_%i_init' % self._tracker_id, json.dumps(dict(
+        self._callback('tracker_%s_init' % self._tracker_id, json.dumps(dict(
             callback=None,
             alpha=self._alpha,
             chance=self._chance,
@@ -666,12 +666,12 @@ class TrackerBinom(object):
 
         if self._stopped:
             self._callback(
-                'tracker_%i_stop' % self._tracker_id, json.dumps(dict(
+                'tracker_%s_stop' % self._tracker_id, json.dumps(dict(
                     responses=[int(s) for s in self._responses],
                     p_val=self._p_val,
                     success=int(self.success))))
         else:
-            self._callback('tracker_%i_respond' % self._tracker_id, correct)
+            self._callback('tracker_%s_respond' % self._tracker_id, correct)
 
     # =========================================================================
     # Define all the public properties
@@ -842,7 +842,7 @@ class TrackerDealer(object):
         self._callback('dealer_identify', json.dumps(dict(
             dealer_id=self._dealer_id)))
 
-        self._callback('dealer_%i_init' % self._dealer_id, json.dumps(dict(
+        self._callback('dealer_%s_init' % self._dealer_id, json.dumps(dict(
             trackers=[s._tracker_id for s in self._trackers.ravel()],
             shape=self._shape,
             max_lag=self._max_lag,
@@ -918,7 +918,7 @@ class TrackerDealer(object):
         self._response_history = np.append(self._response_history, correct)
         if self.stopped:
             self._callback(
-                'dealer_%i_stop' % self._dealer_id, json.dumps(dict(
+                'dealer_%s_stop' % self._dealer_id, json.dumps(dict(
                     tracker_history=[int(s) for s in self._tracker_history],
                     response_history=[float(s) for s in
                                       self._response_history],

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -222,7 +222,7 @@ def test_ec(ac=None, rd=None):
         ec.load_buffer(np.zeros((100, 2)))
         ec.load_buffer(np.zeros((1, 100)))
         ec.load_buffer(np.zeros((2, 100)))
-        data = np.empty(int(5e6), np.float32)  # too long for TDT
+        data = np.zeros(int(5e6), np.float32)  # too long for TDT
         if this_fs == get_tdt_rates()['25k']:
             assert_raises(RuntimeError, ec.load_buffer, data)
         else:
@@ -277,7 +277,7 @@ def test_ec(ac=None, rd=None):
         #
         # First: identify_trial
         #
-        noise = np.random.normal(scale=0.03, size=(int(ec.fs),))
+        noise = np.random.normal(scale=0.01, size=(int(ec.fs),))
         ec.load_buffer(noise)
         assert_raises(RuntimeError, ec.start_stimulus)  # order violation
         assert_true(ec._playing is False)

--- a/expyfun/visual/_visual.py
+++ b/expyfun/visual/_visual.py
@@ -1053,7 +1053,8 @@ class Video(object):
         self._ec = ec
         self._source = load(file_name)
         self._player = Player()
-        self._player.queue(self._source)
+        with warnings.catch_warnings(record=True):  # deprecated eos_action
+            self._player.queue(self._source)
         self._player._audio_player = None
         frame_rate = self.frame_rate
         if frame_rate is None:


### PR DESCRIPTION
@rkmaddox @maddycapp27 because trackers are identified by their memory location, it is actually possible for tracker names to repeat in the unlucky case where the same memory address is used by multiple trackers (e.g., one is instantiated after another is garbage collected). I hit such a use case recently. This fixes the reconstruction.

Should we also fix the naming, e.g. by also tagging with the time of instantiation (to the millisecond), too?