### PR TITLE
MRG: Add unsafe flipping mode

### DIFF
--- a/examples/sync/sync_test.py
+++ b/examples/sync/sync_test.py
@@ -5,8 +5,8 @@ A-V sync test
 
 This example tests synchronization between the screen and the audio playback.
 
-.. note: On Linux (w/NVIDIA), XFCE has been observed to give consistent
-         timings, whereas Compiz WMs did not (doubled timings).
+.. note:: On Linux (w/NVIDIA), XFCE has been observed to give consistent
+          timings, whereas Compiz WMs did not (doubled timings).
 """
 # Author: Dan McCloy <drmccloy@uw.edu>
 #
@@ -25,7 +25,7 @@ print(__doc__)
 with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
                           participant='s', session='0', output_dir=None,
                           suppress_resamp=True, check_rms=None,
-                          version='dev') as ec:
+                          version='dev', safe_flipping=True) as ec:
     ec.load_buffer(np.r_[0.1, np.zeros(99)])  # RMS == 0.01
     pressed = None
     screenshot = None

--- a/examples/sync/sync_test.py
+++ b/examples/sync/sync_test.py
@@ -25,7 +25,7 @@ print(__doc__)
 with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
                           participant='s', session='0', output_dir=None,
                           suppress_resamp=True, check_rms=None,
-                          version='dev', safe_flipping=True) as ec:
+                          version='dev') as ec:
     ec.load_buffer(np.r_[0.1, np.zeros(99)])  # RMS == 0.01
     pressed = None
     screenshot = None

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -104,6 +104,12 @@ class ExperimentController(object):
         the expected version of the expyfun codebase is being used when running
         experiments. To override version checking (e.g., during development)
         use ``version='dev'``.
+    safe_flipping : bool
+        If False, do not use ``glFinish`` when flipping. This can restore
+        60 Hz on Linux systems where 30 Hz framerates occur, but the timing
+        is not necessarily guaranteed, as the `flip` may return before the
+        stimulus has actually flipped (check with
+        :ref:`sphx_glr_auto_examples_sync_sync_test.py`).
     verbose : bool, str, int, or None
         If not None, override default verbose level (see expyfun.verbose).
 
@@ -125,7 +131,7 @@ class ExperimentController(object):
                  full_screen=True, force_quit=None, participant=None,
                  monitor=None, trigger_controller=None, session=None,
                  check_rms='windowed', suppress_resamp=False, version=None,
-                 enable_video=False, verbose=None):
+                 enable_video=False, safe_flipping=True, verbose=None):
         # initialize some values
         self._stim_fs = stim_fs
         self._stim_rms = stim_rms
@@ -147,6 +153,10 @@ class ExperimentController(object):
         self._data_file = None
         self._clock = ZeroClock()
         self._master_clock = self._clock.get_time
+        self.safe_flipping = safe_flipping
+        if not self.safe_flipping:
+            logger.warning('Unsafe flipping mode enabled, flip timing not '
+                           'guaranteed')
 
         # put anything that could fail in this block to ensure proper cleanup!
         try:
@@ -891,7 +901,9 @@ class ExperimentController(object):
         call_list = self._on_next_flip + self._on_every_flip
         self._win.dispatch_events()
         self._win.switch_to()
-        gl.glFinish()
+        if self.safe_flipping:
+            # On NVIDIA Linux these calls cause a 2x delay (33ms instead of 16)
+            gl.glFinish()
         self._win.flip()
         # this waits until everything is called, including last draw
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
@@ -900,7 +912,8 @@ class ExperimentController(object):
             gl.glColor4f(0, 0, 0, 0)
         gl.glVertex2i(10, 10)
         gl.glEnd()
-        gl.glFinish()
+        if self.safe_flipping:
+            gl.glFinish()
         flip_time = self.get_time()
         for function in call_list:
             function()

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -104,7 +104,7 @@ class ExperimentController(object):
         the expected version of the expyfun codebase is being used when running
         experiments. To override version checking (e.g., during development)
         use ``version='dev'``.
-    safe_flipping : bool
+    safe_flipping : bool | None
         If False, do not use ``glFinish`` when flipping. This can restore
         60 Hz on Linux systems where 30 Hz framerates occur, but the timing
         is not necessarily guaranteed, as the `flip` may return before the
@@ -131,7 +131,7 @@ class ExperimentController(object):
                  full_screen=True, force_quit=None, participant=None,
                  monitor=None, trigger_controller=None, session=None,
                  check_rms='windowed', suppress_resamp=False, version=None,
-                 enable_video=False, safe_flipping=True, verbose=None):
+                 enable_video=False, safe_flipping=None, verbose=None):
         # initialize some values
         self._stim_fs = stim_fs
         self._stim_rms = stim_rms
@@ -153,10 +153,6 @@ class ExperimentController(object):
         self._data_file = None
         self._clock = ZeroClock()
         self._master_clock = self._clock.get_time
-        self.safe_flipping = safe_flipping
-        if not self.safe_flipping:
-            logger.warning('Unsafe flipping mode enabled, flip timing not '
-                           'guaranteed')
 
         # put anything that could fail in this block to ensure proper cleanup!
         try:
@@ -241,6 +237,14 @@ class ExperimentController(object):
             #
             # set up monitor
             #
+            if safe_flipping is None:
+                safe_flipping = not (get_config('SAFE_FLIPPING', '').lower() ==
+                                     'false')
+            if not safe_flipping:
+                logger.warning('Expyfun: Unsafe flipping mode enabled, flip '
+                               'timing not guaranteed')
+            self.safe_flipping = safe_flipping
+
             if screen_num is None:
                 screen_num = int(get_config('SCREEN_NUM', '0'))
             if monitor is None:


### PR DESCRIPTION
This could be useful e.g. to test video playback smoothness on testing machines.

Closes #356.