### PR TITLE
WIP: Calibration Interrupt

### DIFF
--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -1105,6 +1105,9 @@ class ExperimentController(object):
     def check_force_quit(self):
         """Check to see if any force quit keys were pressed."""
         self._response_handler.check_force_quit()
+    
+    def check_calibration(self):
+        """Check if calibration interrupt keys were pressed."""
 
     def text_input(self, stop_key='return', pos=[0, 0], color='white',
                    font_name='Arial', font_size=24, wrap=True, units='norm',


### PR DESCRIPTION
I'd attempted this before and it was surprisingly messy so guidance/debate is welcome. @larsoner @drammock @rkmaddox 

The goal is to be able to re-calibrate during an experiment when a given key is pressed.

Things to consider:
1. ``ec`` has the button press info but ``el`` needs to be called -- so which should the function live in? I'd previously gotten it to "work" with the function living in ``ec`` and importing ``el`` to ``ec`` after both were initialized but it was pretty gross.
2. Which functions (if any) should automatically check for re-calibration? We'd want to be able to re-calibrate before a trial if the subject isn't able to get fixation (and then probably abort the rest of the trial after calibration) and also between trials (so we could re-calibrate after a break).
3. Any key press functions in input controllers like ``_retrieve_keyboard_events`` or ``_correct_presses`` will need to recognize the calibration key.
