### PR TITLE
ENH: Refocus on Windows

### DIFF
--- a/examples/sync/sync_test.py
+++ b/examples/sync/sync_test.py
@@ -42,6 +42,7 @@ with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
         screenshot = ec.screenshot() if screenshot is None else screenshot
         ec.flip()
         ec.stamp_triggers([2, 4, 8])
+        ec.refocus()
         pressed = ec.wait_one_press(0.5)[0] if not building_doc else '8'
         ec.stop()
 

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -1928,6 +1928,38 @@ class ExperimentController(object):
             return False
         return True
 
+    def refocus(self):
+        """Attempt to grab operating system window manager / keyboard focus.
+
+        This implements platform-specific trickery to bring the window to the
+        top and capture keyboard focus in cases where keyboard input from a
+        subject is mandatory (e.g., when using keyboard as a response device).
+
+        Notes
+        -----
+        For Windows, the solution as adapted from:
+
+            https://stackoverflow.com/questions/916259/win32-bring-a-window-to-top#answer-34414846
+
+        This function currently does nothing on Linux and OSX.
+        """  # noqa: E501
+        if sys.platform == 'win32':
+            from pyglet.libs.win32 import _user32
+            m_hWnd = self._win._hwnd
+            hCurWnd = _user32.GetForegroundWindow()
+            dwMyID = _user32.GetWindowThreadProcessId(m_hWnd, 0)
+            dwCurID = _user32.GetWindowThreadProcessId(hCurWnd, 0)
+            _user32.AttachThreadInput(dwCurID, dwMyID, True)
+            self._win.activate()
+            # _user32.SetWindowPos(m_hWnd, HWND_TOPMOST, 0, 0, 0, 0,
+            #                      SWP_NOSIZE | SWP_NOMOVE)
+            # _user32.SetWindowPos(m_hWnd, HWND_NOTOPMOST, 0, 0, 0, 0,
+            #                      SWP_NOSIZE | SWP_NOMOVE)
+            # _user32.SetForegroundWindow(m_hWnd)
+            # _user32.AttachThreadInput(dwCurID, dwMyID, False)
+            # _user32.SetFocus(m_hWnd)
+            # _user32.SetActiveWindow(m_hWnd)
+
 # ############################## READ-ONLY PROPERTIES #########################
     @property
     def id_types(self):

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -1947,18 +1947,18 @@ class ExperimentController(object):
             from pyglet.libs.win32 import _user32
             m_hWnd = self._win._hwnd
             hCurWnd = _user32.GetForegroundWindow()
-            dwMyID = _user32.GetWindowThreadProcessId(m_hWnd, 0)
-            dwCurID = _user32.GetWindowThreadProcessId(hCurWnd, 0)
-            _user32.AttachThreadInput(dwCurID, dwMyID, True)
-            self._win.activate()
-            # _user32.SetWindowPos(m_hWnd, HWND_TOPMOST, 0, 0, 0, 0,
-            #                      SWP_NOSIZE | SWP_NOMOVE)
-            # _user32.SetWindowPos(m_hWnd, HWND_NOTOPMOST, 0, 0, 0, 0,
-            #                      SWP_NOSIZE | SWP_NOMOVE)
-            # _user32.SetForegroundWindow(m_hWnd)
-            # _user32.AttachThreadInput(dwCurID, dwMyID, False)
-            # _user32.SetFocus(m_hWnd)
-            # _user32.SetActiveWindow(m_hWnd)
+            if hCurWnd != m_hWnd:
+                dwMyID = _user32.GetWindowThreadProcessId(m_hWnd, 0)
+                dwCurID = _user32.GetWindowThreadProcessId(hCurWnd, 0)
+                _user32.AttachThreadInput(dwCurID, dwMyID, True)
+                # _user32.SetWindowPos(m_hWnd, HWND_TOPMOST, 0, 0, 0, 0,
+                #                      SWP_NOSIZE | SWP_NOMOVE)
+                # _user32.SetWindowPos(m_hWnd, HWND_NOTOPMOST, 0, 0, 0, 0,
+                #                      SWP_NOSIZE | SWP_NOMOVE)
+                self._win.activate()  # _user32.SetForegroundWindow(m_hWnd)
+                _user32.AttachThreadInput(dwCurID, dwMyID, False)
+                _user32.SetFocus(m_hWnd)
+                _user32.SetActiveWindow(m_hWnd)
 
 # ############################## READ-ONLY PROPERTIES #########################
     @property

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -370,6 +370,7 @@ def test_ec(ac=None, rd=None):
         print(test_pix)
         # test __repr__
         assert all([x in repr(ec) for x in ['foo', '"test"', '01']])
+        ec.refocus()  # smoke test for refocusing
     del ec
 
 


### PR DESCRIPTION
The procedure to test in case someone is curious, only on Windows (for now):

1. On `master`, run `sync_test.py` with `response_device='keyboard'`:
    1. Press any key (like space) and notice the flashing speeds up (because it does not wait the 0.5 sec.) 
    2. Press alt-tab to switch to any other process
    3. Press any key (like space) and notice the flashing does not change, and pressing "ctrl" does not close the window.
    4. Click in the expyfun window
    5. Press "ctrl" to close the window (it closes).
2. On this branch, repeat the above, but steps (iv) is not necessary to get step (v) behavior -- it happens already on step (iii) (i.e., focus is regained automatically).