### PR TITLE
fix: class 'Raw' doesn't work with current pyeparse

### DIFF
--- a/expyfun/codeblocks/_pupillometry.py
+++ b/expyfun/codeblocks/_pupillometry.py
@@ -23,7 +23,7 @@ def _load_raw(el, fname):
     fname = el.transfer_remote_file(fname)
     # Load and parse data
     logger.info('Pupillometry: Parsing local file "{0}"'.format(fname))
-    raw = pyeparse.Raw(fname)
+    raw = pyeparse.RawEDF(fname)
     raw.remove_blink_artifacts()
     events = raw.find_events('SYNCTIME', 1)
     return raw, events


### PR DESCRIPTION
At some point pyeparse __init__ used to include a line `Raw = RawEDF` (introduced in [this commit](https://github.com/pyeparse/pyeparse/commit/c7f61e84dbad49163fbd3fade103ebf0db700330#diff-51ad22576f4f2ea6d270fed13a3badd3R7) but not sure when it was removed). Anyway, since it was removed the creation of a graph at the end of the pupillometry code block no longer works. This one-liner fixes it.