### PR TITLE
MAINT: Decorate mne tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,10 +63,10 @@ before_install:
       fi;
     - python -m sounddevice
     # Only install these deps if necessary (slow on Py3k)
-    - pip install -q flake8 pyglet mne  # mne is a dependency now that resample is taken from it
+    - pip install -q flake8 pyglet
     # Full dependencies (pandas, mne-python, h5py, joblib)
     - if [ "${DEPS}" != "minimal" ]; then
-        conda install --yes --quiet pandas h5py;
+        conda install --yes --quiet pandas h5py mne;
         pip install -q joblib;
       fi;
     # Import matplotlib ahead of time so it doesn't affect test timings

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,4 +11,4 @@ coverage:
     changes: false
 comment:
   layout: "header, diff, sunburst, uncovered"
-  behavior: default
+  behavior: once

--- a/expyfun/stimuli/tests/test_stimuli.py
+++ b/expyfun/stimuli/tests/test_stimuli.py
@@ -31,6 +31,7 @@ def test_textures():
     assert_allclose(len(x) / 24414., 4., rtol=1e-5)
 
 
+@pytest.mark.timeout(15)
 @requires_lib('h5py')
 def test_hrtf_convolution():
     """Test HRTF convolution."""

--- a/expyfun/stimuli/tests/test_stimuli.py
+++ b/expyfun/stimuli/tests/test_stimuli.py
@@ -20,6 +20,7 @@ std_kwargs = dict(output_dir=None, full_screen=False, window_size=(340, 480),
                   verbose=True, version='dev')
 
 
+@requires_lib('mne')
 def test_textures():
     """Test stimulus textures."""
     texture_ERB()  # smoke test
@@ -146,6 +147,7 @@ def test_rms():
 
 
 @pytest.mark.timeout(15)  # can be slow to load on CIs
+@requires_lib('mne')
 def test_crm(tmpdir):
     """Test CRM Corpus functions."""
     fs = 40000  # native rate, to avoid large resampling delay in testing

--- a/expyfun/tests/test_logging.py
+++ b/expyfun/tests/test_logging.py
@@ -3,13 +3,14 @@ import os
 import pytest
 from expyfun import ExperimentController
 from expyfun._sound_controllers import _AUTO_BACKENDS
-from expyfun._utils import _check_skip_backend
+from expyfun._utils import _check_skip_backend, requires_lib
 
 std_args = ['test']
 std_kwargs = dict(participant='foo', session='01', full_screen=False,
                   window_size=(1, 1), verbose=True, noise_db=0, version='dev')
 
 
+@requires_lib('mne')
 @pytest.mark.parametrize('ac', ('tdt',) + _AUTO_BACKENDS)
 def test_logging(ac, tmpdir, hide_window):
     """Test logging to file (Pyglet)."""


### PR DESCRIPTION
Should get CIs green and allow us to wait on dropping 2.7 support a bit longer if we want.