### PR TITLE
MRG: Add multi-channel support, fixed delay

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -235,7 +235,7 @@ trim_doctests_flags = True
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'numpy': ('https://www.numpy.org/devdocs', None),
+    'numpy': ('https://numpy.org/devdocs', None),
     'scipy': ('https://scipy.github.io/devdocs', None),
     'matplotlib': ('https://matplotlib.org', None),
     'sklearn': ('https://scikit-learn.org/stable', None),

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -26,9 +26,11 @@ expyfun requires several libraries for full functionality:
   - ``matplotlib``
   - ``pyglet``: 1.2.0 or later is recommended
 
-- Optional Python libraries:
+- Optional libraries:
 
   - ``rtmixer``: for high precision audio playback, see :ref:`rtmixer_installation`.
+  - ``pyparallel`` or ``inpout32.dll``: for parallel port triggering, see
+    :ref:`parallel_installation`.
   - ``TDTpy``: if using TDT on Windows
   - ``mne``: for filtering/resampling -- with CUDA if mne dependencies installed
   - ``pandas``: Some plotting functions

--- a/doc/parallel_installation.rst
+++ b/doc/parallel_installation.rst
@@ -32,10 +32,16 @@ Instructions differ between Linux and Windows:
     If you are on a modern Windows system (i.e., 64-bit), you'll need to:
 
     - Download the latest "binaries" archive from the `InpOut32 site`_
-    - Extract the **64-bit** file ``inpoutx64.dll`` from the ``.zip`` file
-    - Rename this file ``inpout32.dll``
-    - Place it in ``C:\Windows\System32\``
-    - Use the Device Manager to get the parallel port address, e.g.
-      ``'0x378'``, and set this as ``TRIGGER_ADDRESS`` in the config.
+    - Extract the files
+    - Run the ``Win32\InstallDriver.exe`` file (yes, even though it's in the
+      Win32 directory)
+    - Rename the **64-bit** file ``inpoutx64.dll`` to ``inpout32.dll``
+    - Place this file in ``C:\Windows\System32\``
+    - Use the Device Manager (or some other method) to get the parallel port
+      address (from Ports➡Properties➡Resources➡I/O Range), e.g. ``0x378``
+      or ``0xCFF4``, and set this as ``TRIGGER_ADDRESS`` in the config.
+    - If you have trouble, you can interactively test your parallel port using
+      the `parallel port tester application`_.
 
 .. _`InpOut32 site`: http://www.highrez.co.uk/downloads/inpout32/
+.. _`parallel port tester application`: https://www.downtowndougbrown.com/2013/06/parallel-port-tester/

--- a/doc/parallel_installation.rst
+++ b/doc/parallel_installation.rst
@@ -1,0 +1,41 @@
+:orphan:
+
+.. _parallel_installation:
+
+Parallel port triggering
+========================
+
+.. highlight:: console
+
+A PCIe device such as "StarTech.com 1 Port PCI Express" should work.
+USB to parallel port adapters will not, due to hardware limitations of
+the devices ($10 ones on Amazon are only designed for printers) and the
+USB protocol itself, which is not designed for low-latency control.
+
+Instructions differ between Linux and Windows:
+
+- |linux| Linux
+    On Linux, you need ``pyparallel``::
+
+        $ pip install pyparallel
+
+    You might also need some combination of the following:
+
+    1. ``$ sudo modprobe ppdev``
+    2. Add user to lp group (``/etc/group``)
+    3. Run ``sudo rmmod lp`` (otherwise lp takes exclusive control)
+    4. Edit ``/etc/modprobe.d/blacklist.conf`` to add blacklist ``lp``
+    5. ``$ ls /dev/parport*`` to get the parallel port address, e.g.
+       ``'/dev/parport0'``, and set this as ``TRIGGER_ADDRESS`` in the config.
+
+- |windows| Windows
+    If you are on a modern Windows system (i.e., 64-bit), you'll need to:
+
+    - Download the latest "binaries" archive from the `InpOut32 site`_
+    - Extract the **64-bit** file ``inpoutx64.dll`` from the ``.zip`` file
+    - Rename this file ``inpout32.dll``
+    - Place it in ``C:\Windows\System32\``
+    - Use the Device Manager to get the parallel port address, e.g.
+      ``'0x378'``, and set this as ``TRIGGER_ADDRESS`` in the config.
+
+.. _`InpOut32 site`: http://www.highrez.co.uk/downloads/inpout32/

--- a/doc/rtmixer_installation.rst
+++ b/doc/rtmixer_installation.rst
@@ -44,7 +44,7 @@ Here are some stub installation instructions for each OS:
 
     .. code-block:: console
 
-       $ pip install python-sounddevice
+       $ pip install sounddevice
        $ python -m sounddevice  # just to see if it worked
        $ pip install https://staff.washington.edu/larsoner/rtmixer-0.0.0-cp37-cp37m-win_amd64.whl
 

--- a/examples/sync/sync_test.py
+++ b/examples/sync/sync_test.py
@@ -26,13 +26,13 @@ with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
                           participant='s', session='0', output_dir=None,
                           suppress_resamp=True, check_rms=None,
                           version='dev') as ec:
+    ec.load_buffer(np.r_[0.1, np.zeros(99)])  # RMS == 0.01
     pressed = None
     screenshot = None
     # Make a circle so that the photodiode can be centered on the screen
     circle = Circle(ec, 1, units='deg', fill_color='k', line_color='w')
     while pressed != '8':  # enable a clean quit if required
         ec.set_background_color('white')
-        ec.load_buffer(np.r_[0.1, np.zeros(99)])  # RMS == 0.01
         t1 = ec.start_stimulus(start_of_trial=False)  # skip checks
         ec.set_background_color('black')
         t2 = ec.flip()

--- a/examples/sync/sync_test.py
+++ b/examples/sync/sync_test.py
@@ -26,7 +26,7 @@ with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
                           participant='s', session='0', output_dir=None,
                           suppress_resamp=True, check_rms=None,
                           version='dev') as ec:
-    ec.load_buffer(np.r_[0.1, np.zeros(99)])  # RMS == 0.01
+    ec.load_buffer(np.r_[0.1, np.zeros(44100)])  # RMS == 0.01
     pressed = None
     screenshot = None
     # Make a circle so that the photodiode can be centered on the screen

--- a/examples/sync/sync_test.py
+++ b/examples/sync/sync_test.py
@@ -26,7 +26,7 @@ with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
                           participant='s', session='0', output_dir=None,
                           suppress_resamp=True, check_rms=None,
                           version='dev') as ec:
-    ec.load_buffer(np.r_[0.1, np.zeros(44100)])  # RMS == 0.01
+    ec.load_buffer(np.r_[0.1, np.zeros(99)])  # RMS == 0.01
     pressed = None
     screenshot = None
     # Make a circle so that the photodiode can be centered on the screen

--- a/examples/sync/sync_test.py
+++ b/examples/sync/sync_test.py
@@ -26,13 +26,13 @@ with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
                           participant='s', session='0', output_dir=None,
                           suppress_resamp=True, check_rms=None,
                           version='dev') as ec:
-    ec.load_buffer(np.r_[0.1, np.zeros(99)])  # RMS == 0.01
     pressed = None
     screenshot = None
     # Make a circle so that the photodiode can be centered on the screen
     circle = Circle(ec, 1, units='deg', fill_color='k', line_color='w')
     while pressed != '8':  # enable a clean quit if required
         ec.set_background_color('white')
+        ec.load_buffer(np.r_[0.1, np.zeros(99)])  # RMS == 0.01
         t1 = ec.start_stimulus(start_of_trial=False)  # skip checks
         ec.set_background_color('black')
         t2 = ec.flip()

--- a/examples/sync/sync_test.py
+++ b/examples/sync/sync_test.py
@@ -22,11 +22,16 @@ print(__doc__)
 
 
 # Fullscreen MUST be used to guarantee flip accuracy!
+n_channels = 2
+click_idx = 0
 with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
                           participant='s', session='0', output_dir=None,
                           suppress_resamp=True, check_rms=None,
-                          version='dev') as ec:
-    ec.load_buffer(np.r_[0.1, np.zeros(99)])  # RMS == 0.01
+                          n_channels=n_channels, version='dev') as ec:
+    click = np.r_[0.1, np.zeros(99)]  # RMS = 0.01
+    data = np.zeros((n_channels, len(click)))
+    data[click_idx] = click
+    ec.load_buffer(data)
     pressed = None
     screenshot = None
     # Make a circle so that the photodiode can be centered on the screen

--- a/expyfun/__init__.py
+++ b/expyfun/__init__.py
@@ -24,6 +24,7 @@ from . import analyze
 from . import codeblocks
 from . import io
 from . import stimuli
+from . import _fixes
 
 # INIT LOGGING
 set_log_level(None, False)

--- a/expyfun/_fixes.py
+++ b/expyfun/_fixes.py
@@ -1,0 +1,5 @@
+# Prefer newest SciPy interface
+try:
+    from scipy.fft import rfft, irfft, rfftfreq  # noqa
+except ImportError:
+    from numpy.fft import rfft, irfft, rfftfreq  # noqa

--- a/expyfun/_sound_controllers/__init__.py
+++ b/expyfun/_sound_controllers/__init__.py
@@ -1,6 +1,3 @@
 from ._sound_controller import (SoundCardController, SoundPlayer, _BACKENDS,
                                 _import_backend)
-
 _AUTO_BACKENDS = ('auto',) + _BACKENDS
-_SOUND_CARD_ACS = tuple({'TYPE': 'sound_card', 'SOUND_CARD_BACKEND': backend}
-                        for backend in _AUTO_BACKENDS)

--- a/expyfun/_sound_controllers/_pyglet.py
+++ b/expyfun/_sound_controllers/_pyglet.py
@@ -47,11 +47,12 @@ def _check_pyglet_audio():
 class SoundPlayer(Player):
     """SoundPlayer based on Pyglet."""
 
-    def __init__(self, data, fs=None, loop=False, api=None, name=None):
+    def __init__(self, data, fs=None, loop=False, api=None, name=None,
+                 fixed_delay=None):
         assert AudioFormat is not None
-        if api is not None or name is not None:
+        if any(x is not None for x in (api, name, fixed_delay)):
             raise ValueError('The Pyglet backend does not support specifying '
-                             'api or name')
+                             'api, name, or fixed_delay')
         # We could maybe let Pyglet make this decision, but hopefully
         # people won't need to tweak the Pyglet backend anyway
         self.fs = 44100 if fs is None else fs

--- a/expyfun/_sound_controllers/_rtmixer.py
+++ b/expyfun/_sound_controllers/_rtmixer.py
@@ -129,7 +129,7 @@ class SoundPlayer(object):
             else:
                 self._action = self._mixer.play_buffer(
                     self._data, self._data.shape[1])
-                #    start=self._mixer.time - self._mixer.start_time + 0.06)
+                    # start=self._mixer.time + 0.01)
 
     def pause(self):
         """Pause."""

--- a/expyfun/_sound_controllers/_rtmixer.py
+++ b/expyfun/_sound_controllers/_rtmixer.py
@@ -4,6 +4,7 @@
 #
 # License: BSD (3-clause)
 
+import atexit
 import sys
 
 import numpy as np
@@ -15,16 +16,12 @@ from .._utils import logger, get_config
 _PRIORITY = 100
 _DEFAULT_NAME = None
 
+# only initialize each mixer once and reuse it until Python closes
+_MIXER_REGISTRY = {}
 
-# XXX we should really use the sys config to choose the fs, then resample
-# in software...
 
-def _init_mixer(fs, n_channels, api=None, name=None):
+def _get_mixer(fs, n_channels, api=None, name=None):
     """Select the API and device."""
-    devices = query_devices()
-    if len(devices) == 0:
-        raise OSError('No sound devices found!')
-    apis = query_hostapis()
     # API
     if api is None:
         api = get_config('SOUND_CARD_API', None)
@@ -36,6 +33,17 @@ def _init_mixer(fs, n_channels, api=None, name=None):
             win32='Windows WASAPI',
             linux='ALSA',
         )[sys.platform]
+    key = (fs, n_channels, api, name)
+    if key not in _MIXER_REGISTRY:
+        _MIXER_REGISTRY[key] = _init_mixer(fs, n_channels, api, name)
+    return _MIXER_REGISTRY[key]
+
+
+def _init_mixer(fs, n_channels, api, name):
+    devices = query_devices()
+    if len(devices) == 0:
+        raise OSError('No sound devices found!')
+    apis = query_hostapis()
     for ai, this_api in enumerate(apis):
         if this_api['name'] == api:
             api = this_api
@@ -87,24 +95,23 @@ def _init_mixer(fs, n_channels, api=None, name=None):
         mixer.start_time = 0
     logger.info('Expyfun: using %s, %0.1f ms latency'
                 % (param_str, 1000 * device['default_low_output_latency']))
+    atexit.register(lambda: (mixer.abort(), mixer.close()))
     return mixer
 
 
 class SoundPlayer(object):
     """SoundPlayer based on rtmixer."""
 
-    def __init__(self, data, fs=None, loop=False, api=None, name=None):
+    def __init__(self, data, fs=None, loop=False, api=None, name=None,
+                 fixed_delay=None):
         self._data = np.ascontiguousarray(
-            np.clip(data.T, -1, 1).astype(np.float32))
+            np.clip(np.atleast_2d(data).T, -1, 1).astype(np.float32))
         self.loop = bool(loop)
         self._n_samples, n_channels = self._data.shape
-        assert n_channels in (1, 2)
-        if n_channels == 1:
-            self._data = np.tile(self._data, (2, 1))
-            n_channels = 2
+        assert n_channels >= 1
         self._n_channels = n_channels
         self._mixer = None  # in case the next line crashes, __del__ works
-        self._mixer = _init_mixer(fs, self._n_channels, api, name)
+        self._mixer = _get_mixer(fs, self._n_channels, api, name)
         if loop:
             self._ring = RingBuffer(self._data.itemsize * self._n_channels,
                                     self._data.size)
@@ -112,6 +119,12 @@ class SoundPlayer(object):
         self._fs = float(self._mixer.samplerate)
         self._ec_duration = self._n_samples / self._fs
         self._action = None
+        self._fixed_delay = fixed_delay
+        if fixed_delay is not None:
+            logger.info('Expyfun: Using fixed audio delay %0.1f ms'
+                        % (1000 * fixed_delay,))
+        else:
+            logger.info('Expyfun: Variable audio delay')
 
     @property
     def fs(self):
@@ -123,13 +136,17 @@ class SoundPlayer(object):
 
     def play(self):
         """Play."""
-        if not self.playing:
+        if not self.playing and self._mixer is not None:
             if self.loop:
                 self._action = self._mixer.play_ringbuffer(self._ring)
             else:
+                if self._fixed_delay is not None:
+                    start = self._mixer.time + self._fixed_delay
+                else:
+                    start = 0
                 self._action = self._mixer.play_buffer(
-                    self._data, self._data.shape[1])
-                    # start=self._mixer.time + 0.01)
+                    self._data, self._data.shape[1],
+                    start=start)
 
     def pause(self):
         """Pause."""
@@ -143,14 +160,12 @@ class SoundPlayer(object):
 
     def delete(self):
         """Delete."""
-        if self._mixer is not None:
+        if getattr(self, '_mixer', None) is not None:
             self.pause()
             mixer, self._mixer = self._mixer, None
             stats = mixer.fetch_and_reset_stats().stats
             logger.exp('%d underflows %d blocks'
                        % (stats.output_underflows, stats.blocks))
-            mixer.abort()
-            mixer.close()
 
     def __del__(self):
         self.delete()

--- a/expyfun/_sound_controllers/_rtmixer.py
+++ b/expyfun/_sound_controllers/_rtmixer.py
@@ -66,7 +66,7 @@ def _init_mixer(fs, n_channels, api, name):
     for di, device in enumerate(devices):
         if device['hostapi'] == ai:
             possible.append(device['name'])
-            if name == device['name']:
+            if name in device['name']:
                 break
     else:
         raise RuntimeError('Could not find device on API %r with name '

--- a/expyfun/_tdt_controller.py
+++ b/expyfun/_tdt_controller.py
@@ -127,6 +127,7 @@ class TDTController(Keyboard):  # lgtm [py/missing-call-to-init]
         if tdt_params['TDT_INTERFACE'] is None:
             tdt_params['TDT_INTERFACE'] = 'USB'
         self._interface = tdt_params['TDT_INTERFACE']
+        self._n_channels = 2
 
         # initialize RPcoX connection
         """

--- a/expyfun/_trigger_controllers.py
+++ b/expyfun/_trigger_controllers.py
@@ -28,6 +28,8 @@ class ParallelTrigger(object):
         The address to use. On Linux this should be a string path like
         ``'/dev/parport0'`` (equivalent to None), on Windows it should be an
         integer address like ``888`` or ``0x378`` (equivalent to None).
+        The config variable ``TRIGGER_ADDRESS`` can be used to set this
+        permanently.
     high_duration : float
         Amount of time (seconds) to leave the trigger high whenever
         sending a trigger.
@@ -38,18 +40,6 @@ class ParallelTrigger(object):
     -----
     Parallel port activation is enabled by using the ``trigger_controller``
     argument of :class:`expyfun.ExperimentController`.
-
-    On Linux, parallel port may require some combination of the following:
-
-        1. ``sudo modprobe ppdev``
-        2. Add user to ``lp`` group (``/etc/group``)
-        3. Run ``sudo rmmod lp`` (otherwise ``lp`` takes exclusive control)
-        4. Edit ``/etc/modprobe.d/blacklist.conf`` to add ``blacklist lp``
-
-    The ``parallel`` module must also be installed.
-
-    On Windows, you may need to download ``inpout32.dll`` from someplace
-    like http://www.highrez.co.uk/downloads/inpout32/.
     """
 
     @verbose_dec

--- a/expyfun/_trigger_controllers.py
+++ b/expyfun/_trigger_controllers.py
@@ -8,7 +8,7 @@
 import sys
 import numpy as np
 
-from ._utils import wait_secs, verbose_dec, string_types
+from ._utils import wait_secs, verbose_dec, string_types, logger
 
 
 class ParallelTrigger(object):
@@ -52,6 +52,7 @@ class ParallelTrigger(object):
                     raise ValueError('addrss must be a string or None, got %s '
                                      'of type %s' % (address, type(address)))
                 from parallel import Parallel
+                logger.info('Expyfun: Using address %s' % (address,))
                 self._port = Parallel(address)
                 self._portname = address
                 self._set_data = self._port.setData
@@ -62,7 +63,8 @@ class ParallelTrigger(object):
                         'Must have inpout32 installed, see:\n\n'
                         'http://www.highrez.co.uk/downloads/inpout32/')
 
-                base = 0x378 if address is None else address
+                base = '0x378' if address is None else address
+                logger.info('Expyfun: Using base address %s' % (base,))
                 if isinstance(base, string_types):
                     base = int(base, 16)
                 if not isinstance(base, int):

--- a/expyfun/conftest.py
+++ b/expyfun/conftest.py
@@ -5,6 +5,7 @@
 
 import os
 import pytest
+from expyfun._sound_controllers import _AUTO_BACKENDS
 
 
 @pytest.mark.timeout(0)  # importing plt will build font cache, slow on Azure
@@ -31,3 +32,17 @@ def hide_window():
         pyglet.window.get_platform().get_default_display()
     except Exception as exp:
         pytest.skip('Pyglet windowing unavailable (%s)' % exp)
+
+
+_SOUND_CARD_ACS = tuple({'TYPE': 'sound_card', 'SOUND_CARD_BACKEND': backend}
+                        for backend in _AUTO_BACKENDS)
+for val in _SOUND_CARD_ACS:
+    if val['SOUND_CARD_BACKEND'] == 'pyglet':
+        val.update(SOUND_CARD_API=None, SOUND_CARD_NAME=None,
+                   SOUND_CARD_FIXED_DELAY=None)
+
+
+@pytest.fixture(scope="module", params=('tdt',) + _SOUND_CARD_ACS)
+def ac(request):
+    """Get the backend name."""
+    yield request.param

--- a/expyfun/stimuli/_hrtf.py
+++ b/expyfun/stimuli/_hrtf.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from ..io import read_hdf5
+from .._fixes import irfft
 from .._utils import fetch_data_file, _fix_audio_dims
 
 # This was used to generate "barb_anech.gz":
@@ -104,7 +105,7 @@ def _get_hrtf(angle, source, fs, interp=False):
 
         # reconstruct hrtf and convert to time domain
         hrtf = hrtf_amp * np.exp(1j * hrtf_phase)
-        brir = np.fft.irfft(hrtf, int(hrtf.shape[-1]))
+        brir = irfft(hrtf, int(hrtf.shape[-1]))
 
     return brir, data['fs'], leftward
 

--- a/expyfun/stimuli/_mls.py
+++ b/expyfun/stimuli/_mls.py
@@ -8,6 +8,7 @@
 from os import path as op
 import numpy as np
 
+from .._fixes import irfft, rfft
 from .._utils import verbose_dec, logger
 
 _mls_file = op.join(op.dirname(__file__), '..', 'data', 'mls.bin')
@@ -126,9 +127,7 @@ def compute_mls_impulse_response(response, mls, n_repeats, verbose=None):
     correction = np.empty(len(mls) // 2 + 1)
     correction.fill(1. / (2 ** (n_bits - 2) * n_repeats))
     correction[0] = 1. / ((4 ** (n_bits - 1)) * n_repeats)
-    y = np.fft.irfft(correction *
-                     np.fft.rfft(resp_wrap) *
-                     np.fft.rfft(mls).conj())
+    y = irfft(correction * rfft(resp_wrap) * rfft(mls).conj())
     # Average out repeats
     h_est = np.mean(np.reshape(y, (n_repeats, mls_len)), axis=0)
     return h_est

--- a/expyfun/stimuli/_texture.py
+++ b/expyfun/stimuli/_texture.py
@@ -8,6 +8,7 @@ import numpy as np
 import warnings
 
 from ._stimuli import rms, window_edges
+from .._fixes import irfft
 
 
 def _cams(f):
@@ -36,8 +37,7 @@ def _make_narrow_noise(bw, f_c, dur, fs, ramp_dur, rng):
     phase = rng.rand(h_max - h_min) * 2 * np.pi
     noise = np.zeros(len(t) // 2 + 1, np.complex)
     noise[h_min:h_max] = np.exp(1j * phase)
-    return window_edges(np.fft.irfft(noise)[:len(t)], fs, ramp_dur,
-                        window='dpss')
+    return window_edges(irfft(noise)[:len(t)], fs, ramp_dur, window='dpss')
 
 
 def texture_ERB(n_freqs=20, n_coh=None, rho=1., seq=('inc', 'nb', 'inc', 'nb'),

--- a/expyfun/stimuli/tests/test_tracker.py
+++ b/expyfun/stimuli/tests/test_tracker.py
@@ -15,7 +15,7 @@ def callback(event_type, value=None, timestamp=None):
 std_kwargs = dict(output_dir=None, full_screen=False, window_size=(1, 1),
                   participant='foo', session='01', stim_db=0.0, noise_db=0.0,
                   trigger_controller='dummy', response_device='keyboard',
-                  audio_controller='pyglet',
+                  audio_controller='sound_card',
                   verbose=True, version='dev')
 
 

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -466,7 +466,7 @@ def test_button_presses_and_window_size(hide_window):
         # XXX this fails on OSX travis for some reason
         if (os.getenv('TRAVIS', '').lower() != 'true' or
                 sys.platform != 'darwin'):
-            assert ec.text_input(all_caps=False) == 'a'
+            assert ec.text_input(all_caps=False).strip() == 'a'
 
 
 @pytest.mark.timeout(10)

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -8,7 +8,6 @@ import pytest
 from numpy.testing import assert_allclose
 
 from expyfun import ExperimentController, wait_secs, visual
-from expyfun._sound_controllers import _SOUND_CARD_ACS
 from expyfun._utils import (_TempDir, fake_button_press, _check_skip_backend,
                             fake_mouse_click, requires_opengl21)
 from expyfun.stimuli import get_tdt_rates
@@ -156,8 +155,7 @@ def test_degenerate():
                   **std_kwargs)
 
 
-@pytest.mark.timeout(10)
-@pytest.mark.parametrize('ac', ('tdt',) + _SOUND_CARD_ACS)
+@pytest.mark.timeout(20)
 def test_ec(ac, hide_window):
     """Test EC methods."""
     if ac == 'tdt':
@@ -215,8 +213,10 @@ def test_ec(ac, hide_window):
         ec.load_buffer([0, 0, 0, 0, 0, 0])
         pytest.raises(ValueError, ec.load_buffer, [0, 2, 0, 0, 0, 0])
         ec.load_buffer(np.zeros((100,)))
-        ec.load_buffer(np.zeros((100, 1)))
-        ec.load_buffer(np.zeros((100, 2)))
+        with pytest.raises(ValueError, match='100 did not match .* count 2'):
+            ec.load_buffer(np.zeros((100, 1)))
+        with pytest.raises(ValueError, match='100 did not match .* count 2'):
+            ec.load_buffer(np.zeros((100, 2)))
         ec.load_buffer(np.zeros((1, 100)))
         ec.load_buffer(np.zeros((2, 100)))
         data = np.zeros(int(5e6), np.float32)  # too long for TDT

--- a/expyfun/tests/test_logging.py
+++ b/expyfun/tests/test_logging.py
@@ -47,6 +47,7 @@ def test_logging(ac, tmpdir, hide_window):
 
 
 def assert_have_all(data, should_have):
+    """Assert all substrings are in the logging output."""
     __tracebackhide__ = operator.methodcaller('errisinstance', AssertionError)
     for s in should_have:
         if s not in data:

--- a/expyfun/tests/test_logging.py
+++ b/expyfun/tests/test_logging.py
@@ -1,8 +1,8 @@
+import operator
 import os
 
 import pytest
 from expyfun import ExperimentController
-from expyfun._sound_controllers import _AUTO_BACKENDS
 from expyfun._utils import _check_skip_backend, requires_lib
 
 std_args = ['test']
@@ -11,7 +11,6 @@ std_kwargs = dict(participant='foo', session='01', full_screen=False,
 
 
 @requires_lib('mne')
-@pytest.mark.parametrize('ac', ('tdt',) + _AUTO_BACKENDS)
 def test_logging(ac, tmpdir, hide_window):
     """Test logging to file (Pyglet)."""
     if ac != 'tdt':
@@ -40,11 +39,16 @@ def test_logging(ac, tmpdir, hide_window):
             should_have.append('TDT')
         else:
             should_have.append('sound card')
-            if ac != 'auto':
-                should_have.append(ac)
-        for s in should_have:
-            if s not in data:
-                raise ValueError('Missing data: "{0}" in:\n{1}'
-                                 ''.format(s, data))
+            if ac != 'auto' and ac['SOUND_CARD_BACKEND'] != 'auto':
+                should_have.append(ac['SOUND_CARD_BACKEND'])
+        assert_have_all(data, should_have)
     finally:
         os.chdir(orig_dir)
+
+
+def assert_have_all(data, should_have):
+    __tracebackhide__ = operator.methodcaller('errisinstance', AssertionError)
+    for s in should_have:
+        if s not in data:
+            raise AssertionError('Missing data: "{0}" in:\n{1}'
+                                 ''.format(s, data))


### PR DESCRIPTION
Haven't tested the multichannel stuff or fixed delay on this branch, but in theory it should work since fixed delay seemed to work with what is now `SOUND_CARD_FIXED_DELAY` added to the time. For my built in sound card on Linux, 10ms (`0.01`) is enough.

@rkmaddox if you are bored feel free to try it, but it might need a bit of work still since I haven't re-tested with a scope or tried my multichannel card, but at least with my `pulse` ALSA "card" (with 32 outputs for some reason) this works in `sync_test.py`:
```
with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
                          participant='s', session='0', output_dir=None,
                          suppress_resamp=True, check_rms=None,
                          version='dev', n_channels=8) as ec:
    ec.load_buffer(np.tile(np.r_[0.1, np.zeros(99)][np.newaxis], (8, 1)))  # RMS == 0.01
```
and the messages are reasonable:
```
2019-07-17 22:53:54,900 - INFO    - Expyfun: Using version 2.0.0.dev0 (requested dev)
2019-07-17 22:53:55,498 - INFO    - Expyfun: Setting up sound card audio using rtmixer backend and 8 channels
2019-07-17 22:53:55,548 - INFO    - Expyfun: using sound card 'pulse' (devices[19]) via 'ALSA', 8 channels @ 44100 Hz, 8.7 ms latency
2019-07-17 22:53:55,548 - INFO    - Expyfun: Variable audio delay
```

Closes #383.