### PR TITLE
MRG: adding extra line for rtmixer installation instructions for linux

### DIFF
--- a/doc/rtmixer_installation.rst
+++ b/doc/rtmixer_installation.rst
@@ -24,7 +24,7 @@ Here are some stub installation instructions for each OS:
        $ python -m sounddevice  # just to see if it worked
        $ git clone git://github.com/spatialaudio/python-rtmixer
        $ cd python-rtmixer
-       $ pip install -e .
+       $ git submodule update --init
 
     .. note:: As an alternative to ``brew`` on macOS, you can also use the
              `PortAudio binaries site`_ to put the ``dylib`` in some

--- a/doc/rtmixer_installation.rst
+++ b/doc/rtmixer_installation.rst
@@ -25,6 +25,8 @@ Here are some stub installation instructions for each OS:
        $ git clone git://github.com/spatialaudio/python-rtmixer
        $ cd python-rtmixer
        $ git submodule update --init
+       $ pip install -e .
+
 
     .. note:: As an alternative to ``brew`` on macOS, you can also use the
              `PortAudio binaries site`_ to put the ``dylib`` in some


### PR DESCRIPTION
Closes #390

Current lines in rtmixer_installation.rst read:
```
       $ sudo apt install libportaudio2  # only if on Linux!
       $ brew install portaudio  # only if on OSX!
       $ pip install sounddevice
       $ python -m sounddevice  # just to see if it worked
       $ git clone git://github.com/spatialaudio/python-rtmixer
       $ cd python-rtmixer
       $ git submodule update --init
       $ pip install -e .
```
Can't find `portaudio` headers
Added a line which worked (instructions came from https://github.com/spatialaudio/python-rtmixer):

```
       $ sudo apt install libportaudio2  # only if on Linux!
       $ brew install portaudio  # only if on OSX!
       $ pip install sounddevice
       $ python -m sounddevice  # just to see if it worked
       $ git clone git://github.com/spatialaudio/python-rtmixer
       $ cd python-rtmixer
       $ git submodule update --init
       $ pip install -e .
```

