### PR TITLE
FIX: Missing triggers

### DIFF
--- a/expyfun/_sound_controllers/_pyglet.py
+++ b/expyfun/_sound_controllers/_pyglet.py
@@ -65,7 +65,7 @@ class SoundPlayer(Player):
         self.queue(group)
         self._ec_duration = sms._duration
 
-    def stop(self, wait=True):
+    def stop(self, wait=True, extra_delay=0.):
         """Stop."""
         self.pause()
         self.seek(0.)

--- a/expyfun/_sound_controllers/_sound_controller.py
+++ b/expyfun/_sound_controllers/_sound_controller.py
@@ -253,10 +253,14 @@ class SoundCardController(object):
         stim.play()
         t_each = self._trigger_duration + delay
         duration = len(triggers) * t_each
+        extra_delay = 0.1
         if not wait_for_last:
-            duration -= (delay - self._trigger_duration)
+            delta = (delay - self._trigger_duration)
+            duration -= delta
+            extra_delay += delta
         wait_secs(duration)
-        stim.stop(wait=False)
+        # Impose an extra delay on the "stop" action
+        stim.stop(wait=False, extra_delay=extra_delay)
 
     def play(self):
         """Play."""


### PR DESCRIPTION
I don't love this fix/workaround but if there is something fishy with the stream time provided by the RME ASIO drivers, this should make sure we don't inadvertently cut off triggers.

Also removes a `mixer.start_time = mixer.time` assignment that is just leftover cruft.