### PR TITLE
FIX: Don't call ion

### DIFF
--- a/expyfun/analyze/_analyze.py
+++ b/expyfun/analyze/_analyze.py
@@ -283,7 +283,6 @@ def rt_chisq(x, axis=None, warn=True):
         >>> import numpy as np
         >>> from scipy import stats as ss
         >>> import matplotlib.pyplot as plt
-        >>> plt.ion()
         >>> x = np.abs(np.random.randn(10000) + 1)
         >>> lsp = np.linspace(np.floor(np.min(x)), np.ceil(np.max(x)), 100)
         >>> df, loc, scale = ss.chi2.fit(x, floc=0)

--- a/expyfun/analyze/tests/test_viz.py
+++ b/expyfun/analyze/tests/test_viz.py
@@ -64,6 +64,7 @@ def test_barplot_single(tmp_err):
     plt.close('all')
 
 
+@pytest.mark.timeout(15)
 def test_barplot_single_spec(tmp_err):
     """Test with one data point per bar and user-specified err ranges."""
     import matplotlib.pyplot as plt
@@ -86,6 +87,7 @@ def test_barplot_single_spec(tmp_err):
     plt.close('all')
 
 
+@pytest.mark.timeout(10)
 def test_barplot_multiple():
     """Test with multiple data points per bar and calculated ranges."""
     import matplotlib.pyplot as plt

--- a/expyfun/analyze/tests/test_viz.py
+++ b/expyfun/analyze/tests/test_viz.py
@@ -33,7 +33,6 @@ def tmp_err():  # noqa
     return tmp, err
 
 
-@pytest.mark.timeout(45)
 def test_barplot_degenerate(tmp_err):
     """Test bar plot degenerate cases."""
     import matplotlib.pyplot as plt
@@ -65,7 +64,6 @@ def test_barplot_single(tmp_err):
     plt.close('all')
 
 
-@pytest.mark.timeout(120)
 def test_barplot_single_spec(tmp_err):
     """Test with one data point per bar and user-specified err ranges."""
     import matplotlib.pyplot as plt
@@ -88,7 +86,6 @@ def test_barplot_single_spec(tmp_err):
     plt.close('all')
 
 
-@pytest.mark.timeout(60)
 def test_barplot_multiple():
     """Test with multiple data points per bar and calculated ranges."""
     import matplotlib.pyplot as plt

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ filterwarnings =
     ignore:.*clock has been deprecated.*:DeprecationWarning
     ignore:the imp module is deprecated.*:DeprecationWarning
     ignore:.*eos_action is deprecated.*:DeprecationWarning
+    ignore:.*ufunc size changed.*:RuntimeWarning
 
 [flake8]
 exclude = __init__.py,decorator.py,ndarraysource.py


### PR DESCRIPTION
Having `ion` in the example makes the tests horribly slow, as they cause `ion` to be on when plotting. This should fix it.