### PR TITLE
FIX: Bump up tolerance for drift

### DIFF
--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -198,7 +198,7 @@ class ExperimentController(object):
             # Use ZeroClock, which uses the "clock" fn but starts at zero
             self._time_corrections = dict()
             self._time_correction_fxns = dict()
-            self._time_correction_maxs = dict()  # optional, defaults to 10e-6
+            self._time_correction_maxs = dict()  # optional, defaults to 50e-6
 
             # dictionary for experiment metadata
             self._exp_info = OrderedDict()
@@ -1898,7 +1898,7 @@ class ExperimentController(object):
             self._time_corrections[clock_type] = time_correction
 
         diff = time_correction - self._time_corrections[clock_type]
-        max_dt = self._time_correction_maxs.get(clock_type, 10e-6)
+        max_dt = self._time_correction_maxs.get(clock_type, 50e-6)
         if np.abs(diff) > max_dt:
             logger.warning('Expyfun: drift of > {} microseconds ({}) '
                            'between {} clock and EC master clock.'


### PR DESCRIPTION
Even when using the same clock 10 µs can be tough with Python overhead. So let's bump our tol up to 50.

cc @maddycapp27 let me know if this works for you. If it does I'll leave open for a bit in case there are other joystick-related fixes we need.