### PR TITLE
MRG, ENH: Check resolution and improve sync_test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
-language: c
+language: generic
 sudo: false
 cache:
-  apt: true
+  pip: true
 env:
     # The _EXPYFUN_SILENT is a workaround for a silly Py3/Travis bug
     global: PYTHON_VERSION=3.7 DISPLAY=:99.0
             CONDA_DEPENDENCIES="scipy matplotlib coverage setuptools pytest pytest-cov pytest-timeout pillow"
-            PIP_DEPENDENCIES="codecov pytest-sugar codespell pydocstyle numpydoc check-manifest sounddevice"
+            PIP_DEPENDENCIES="codecov pytest-sugar codespell pydocstyle numpydoc check-manifest sounddevice rtmixer"
 
 
 matrix:
-  exclude:
-      # Exclude the default Python 2.7 build
-      - python: 2.7
   include:
     - os: linux
       dist: xenial
@@ -26,7 +23,7 @@ matrix:
       language: objective-c
     - os: linux
       dist: trusty
-      env: PYTHON_VERSION=2.7 DEPS=minimal _EXPYFUN_SILENT=true
+      env: PYTHON_VERSION=3.5 DEPS=minimal _EXPYFUN_SILENT=true
       addons:
         apt:
           packages:
@@ -46,9 +43,6 @@ before_install:
     # Easy dependencies (pulseaudio, scipy, matplotlib, pytest, coverage, codecov, flake8)
     - git clone git://github.com/astropy/ci-helpers.git --depth=1
     - source ci-helpers/travis/setup_conda.sh
-    - if [ "${PYTHON_VERSION}" != "2.7" ]; then
-        pip install rtmixer;
-      fi
     # install FFmpeg, sound drivers
     - git clone --depth=1 git://github.com/LABSN/sound-ci-helpers.git;
     - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,8 +28,7 @@ expyfun requires several libraries for full functionality:
   - ``numpy``
   - ``scipy``
   - ``matplotlib``
-  - ``pyglet``: 1.2.0 or later is recommended but 1.4.0 is not fully supported
-    yet, so use e.g. ``pip install "pyglet<1.4"``.
+  - ``pyglet``
 
 - Optional libraries:
 
@@ -54,6 +53,8 @@ Expyfun
 The recommended way to install expyfun on
 development machines is to ``git clone`` the reposity then do:
 
+.. code-block:: console
+
     $ pip install -e .
 
 This allows you to stay up to date with updates, changes, and bugfixes,
@@ -75,9 +76,38 @@ A/V/trigger timing typically requires utilizing:
 - auditory connectors to go 1/4" or 1/8" output->BNC
 - Running :ref:`synchronization_tests`
 
-Once the jitter is sufficiently reduced (e.g., < 1 ms) and delays between
-components are fixed, delays can be corrected through various config
-variable(s) (details TBD).
+To get this to work, you'll need to set up the machine configuration file. This
+ensures that the following things (among others) work correctly:
+
+1. The interface for auditory stimuli.
+2. The interface for triggering.
+3. Units, e.g., ``'deg'`` actually yields degrees.
+4. The display screen resolution in full-screen mode.
+
+The keys that will always need to be set (using :func:`expyfun.set_config` or
+manual JSON editing) include, but are not limited to (all *distances* in cm;
+example values from a fairly typical desktop computer):
+
+``"SCREEN_SIZE_PIX"``
+    Full screen size in pixels.
+``"SCREEN_DISTANCE"``
+    Physical display distance from the subject, e.g., ``"83.0"``.
+``"SCREEN_WIDTH"``
+    Physical display width, e.g., ``"52.0"``.
+
+.. note::
+
+     Another settable parameter is ``"SCREEN_HEIGHT"``, but if you have square
+     display pixels (a sane assumption for reasonable displays) then it's
+     inferred based on the screen size in pixels and physical screen width.
+
+Other settings depend on whether you use TDT / sound card / parallel port for
+auditory stimuli and triggering. Possibilities can be seen by looking at
+:py:obj:`expyfun.known_config_types`. Your current system configuration can be
+viewed by doing::
+
+    >>> expyfun.get_config()
+    {'SCREEN_DISTANCE': '61.0', 'SCREEN_SIZE_PIX': '1920,1200', 'SCREEN_WIDTH': '52.0', 'SOUND_CARD_BACKEND': 'rtmixer'}
 
 Deploying experiments
 ---------------------

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -10,7 +10,7 @@ Getting started
 Installing expyfun
 ------------------
 
-.. highlight:: console
+.. highlight:: python
 
 Python
 ^^^^^^
@@ -72,7 +72,8 @@ A/V/trigger timing typically requires utilizing:
 
 - oscilloscope
 - photodiode
-- parallel port breakout or TDT trigger breakout
+- parallel port breakout, TDT trigger breakout, or sound card SPDIF-to-TTL
+  converter
 - auditory connectors to go 1/4" or 1/8" output->BNC
 - Running :ref:`synchronization_tests`
 
@@ -88,18 +89,16 @@ The keys that will always need to be set (using :func:`expyfun.set_config` or
 manual JSON editing) include, but are not limited to (all *distances* in cm;
 example values from a fairly typical desktop computer):
 
-``"SCREEN_SIZE_PIX"``
-    Full screen size in pixels.
-``"SCREEN_DISTANCE"``
+- ``"SCREEN_SIZE_PIX"``
+    Comma-separated full screen size in pixels, e.g., ``"1920,1200"``.
+- ``"SCREEN_DISTANCE"``
     Physical display distance from the subject, e.g., ``"83.0"``.
-``"SCREEN_WIDTH"``
+- ``"SCREEN_WIDTH"``
     Physical display width, e.g., ``"52.0"``.
 
-.. note::
-
-     Another settable parameter is ``"SCREEN_HEIGHT"``, but if you have square
-     display pixels (a sane assumption for reasonable displays) then it's
-     inferred based on the screen size in pixels and physical screen width.
+Another settable parameter is ``"SCREEN_HEIGHT"``, but if you have square
+display pixels (a sane assumption for reasonable displays) then it's inferred
+based on the screen size in pixels and physical screen width.
 
 Other settings depend on whether you use TDT / sound card / parallel port for
 auditory stimuli and triggering. Possibilities can be seen by looking at
@@ -108,6 +107,58 @@ viewed by doing::
 
     >>> expyfun.get_config()
     {'SCREEN_DISTANCE': '61.0', 'SCREEN_SIZE_PIX': '1920,1200', 'SCREEN_WIDTH': '52.0', 'SOUND_CARD_BACKEND': 'rtmixer'}
+
+.. note::
+
+    If this returns ``{}``, you have not written any config values yet. This
+    means that the standard ``expyfun.json`` file might not exist, and
+    you might want to do something like::
+
+        >>> expyfun.set_config('SCREEN_SIZE_PIX', '1920,1200')
+
+    To initialize the ``expyfun.json`` file.
+
+
+The fixed, hardware-dependent settings for a given system get written to
+an ``expyfun.json`` file. You can use :func:`expyfun.get_config_path` to
+get the path to your config file. Some sample configurations:
+
+- A TDT-based M/EEG+pupillometry machine:
+
+  .. code-block:: JSON
+
+    {
+    "AUDIO_CONTROLLER": "tdt",
+    "EXPYFUN_EYELINK": "100.1.1.1",
+    "RESPONSE_DEVICE": "keyboard",
+    "SCREEN_DISTANCE": "100",
+    "SCREEN_WIDTH": "51",
+    "TDT_DELAY": "44",
+    "TDT_INTERFACE": "GB",
+    "TDT_MODEL": "RZ6",
+    "TDT_TRIG_DELAY": "3",
+    "TRIGGER_CONTROLLER": "tdt"
+    }
+
+- A sound-card-based EEG system:
+
+  .. code-block:: JSON
+
+    {
+    "AUDIO_CONTROLLER": "sound_card",
+    "RESPONSE_DEVICE": "keyboard",
+    "SCREEN_DISTANCE": "50",
+    "SCREEN_SIZE_PIX": "1920,1080",
+    "SCREEN_WIDTH": "53",
+    "SOUND_CARD_API": "ASIO",
+    "SOUND_CARD_BACKEND": "rtmixer",
+    "SOUND_CARD_FIXED_DELAY": 0.03,
+    "SOUND_CARD_FS": 48000,
+    "SOUND_CARD_NAME": "ASIO Fireface USB",
+    "SOUND_CARD_TRIGGER_CHANNELS": 2,
+    "SOUND_CARD_TRIGGER_SCALE": 0.001,
+    "TRIGGER_CONTROLLER": "sound_card"
+    }
 
 Deploying experiments
 ---------------------

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -156,7 +156,6 @@ get the path to your config file. Some sample configurations:
     "SOUND_CARD_FS": 48000,
     "SOUND_CARD_NAME": "ASIO Fireface USB",
     "SOUND_CARD_TRIGGER_CHANNELS": 2,
-    "SOUND_CARD_TRIGGER_SCALE": 0.001,
     "TRIGGER_CONTROLLER": "sound_card"
     }
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -32,6 +32,7 @@ grouped by hardware control type.
    download_version
    get_config
    get_keyboard_input
+   known_config_types
    set_log_level
    set_config
 

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -31,6 +31,7 @@ grouped by hardware control type.
    decimals_to_binary
    download_version
    get_config
+   get_config_path
    get_keyboard_input
    known_config_types
    set_log_level

--- a/examples/sync/sync_test.py
+++ b/examples/sync/sync_test.py
@@ -15,7 +15,7 @@ This example tests synchronization between the screen and the audio playback.
 import numpy as np
 
 from expyfun import ExperimentController, building_doc
-from expyfun.visual import Circle
+from expyfun.visual import Circle, Rectangle
 import expyfun.analyze as ea
 
 print(__doc__)
@@ -36,6 +36,8 @@ with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
     screenshot = None
     # Make a circle so that the photodiode can be centered on the screen
     circle = Circle(ec, 1, units='deg', fill_color='k', line_color='w')
+    # Make a rectangle that is the standard credit card size (~3 3/8" x 2 1/8")
+    rect = Rectangle(ec, [0, 0, 8.56, 5.398], 'cm', None, '#AA3377')
     while pressed != '8':  # enable a clean quit if required
         ec.set_background_color('white')
         t1 = ec.start_stimulus(start_of_trial=False)  # skip checks
@@ -44,6 +46,7 @@ with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
         diff = round(1000 * (t2 - t1), 2)
         ec.screen_text('IFI (ms): {}'.format(diff), wrap=True)
         circle.draw()
+        rect.draw()
         screenshot = ec.screenshot() if screenshot is None else screenshot
         ec.flip()
         ec.stamp_triggers([2, 4, 8])

--- a/examples/sync/sync_test.py
+++ b/examples/sync/sync_test.py
@@ -3,10 +3,32 @@
 A-V sync test
 =============
 
-This example tests synchronization between the screen and the audio playback.
+This example tests synchronization between the screen and the auditory/visual
+playback. If a given machine (experimenta or development) is configured
+correctly:
 
-.. note:: On Linux (w/NVIDIA), XFCE has been observed to give consistent
-          timings, whereas Compiz WMs did not (doubled timings).
+1. The inter-flip interval should be ``1 / refresh_rate``, i.e., ~16 ms for
+   a 60 Hz display.
+2. The red rectangle should correspond to a typical credit card size
+   (~3 3/8" x 2 1/8").
+
+If you test using an oscilloscope, which is required for actual subject
+presentation:
+
+1. There should be no jitter between the trigger and auditory or visual
+   display when hooking the auditory output and photodiode to an oscilloscope.
+2. The auditory and visual onset should be aligned (no fixed delay between
+   them) when viewed with an oscilloscope.
+
+A fixed trigger-to-AV delay can in principle be adjusted afterward via analysis
+changes, and can be assessed using this script and an oscilloscope.
+
+.. warning::
+
+     Fullscreen must be used to guarantee flip accuracy! Also, ensure that if
+     you are using a projector, your computer screen resolution (and
+     ``"SCREEN_SIZE_PIX"``) are configured to use the native resolution of the
+     projector, as resolution conversion can lead to visual display jitter.
 """
 # Author: Dan McCloy <drmccloy@uw.edu>
 #
@@ -20,8 +42,6 @@ import expyfun.analyze as ea
 
 print(__doc__)
 
-
-# Fullscreen MUST be used to guarantee flip accuracy!
 n_channels = 2
 click_idx = [0]
 with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
@@ -36,7 +56,7 @@ with ExperimentController('SyncTest', full_screen=True, noise_db=-np.inf,
     screenshot = None
     # Make a circle so that the photodiode can be centered on the screen
     circle = Circle(ec, 1, units='deg', fill_color='k', line_color='w')
-    # Make a rectangle that is the standard credit card size (~3 3/8" x 2 1/8")
+    # Make a rectangle that is the standard credit card size
     rect = Rectangle(ec, [0, 0, 8.56, 5.398], 'cm', None, '#AA3377')
     while pressed != '8':  # enable a clean quit if required
         ec.set_background_color('white')

--- a/expyfun/__init__.py
+++ b/expyfun/__init__.py
@@ -11,7 +11,7 @@ from ._version import __version__
 from ._utils import (set_log_level, set_log_file, set_config, check_units,
                      get_config, get_config_path, fetch_data_file,
                      run_subprocess)
-from ._utils import verbose_dec as verbose, building_doc
+from ._utils import verbose_dec as verbose, building_doc, known_config_types
 from ._git import assert_version, download_version
 from ._experiment_controller import ExperimentController, get_keyboard_input
 from ._eyelink_controller import EyelinkController

--- a/expyfun/__init__.py
+++ b/expyfun/__init__.py
@@ -10,8 +10,8 @@ from ._version import __version__
 # have to import verbose first since it's needed by many things
 from ._utils import (set_log_level, set_log_file, set_config, check_units,
                      get_config, get_config_path, fetch_data_file,
-                     run_subprocess)
-from ._utils import verbose_dec as verbose, building_doc, known_config_types
+                     run_subprocess, verbose_dec as verbose, building_doc,
+                     known_config_types)
 from ._git import assert_version, download_version
 from ._experiment_controller import ExperimentController, get_keyboard_input
 from ._eyelink_controller import EyelinkController

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -280,7 +280,7 @@ class ExperimentController(object):
                 mon_size = [int(p) for p in mon_size]
                 monitor['SCREEN_SIZE_PIX'] = mon_size
             if not isinstance(monitor, dict):
-                raise TypeError('monitor must be a dict')
+                raise TypeError('monitor must be a dict, got %r' % (monitor,))
             req_mon_keys = ['SCREEN_WIDTH', 'SCREEN_DISTANCE',
                             'SCREEN_SIZE_PIX']
             missing_keys = [key for key in req_mon_keys if key not in monitor]
@@ -377,7 +377,8 @@ class ExperimentController(object):
             #
             logger.info('Expyfun: Setting up screen')
             if full_screen:
-                window_size = monitor['SCREEN_SIZE_PIX']
+                if window_size is None:
+                    window_size = monitor['SCREEN_SIZE_PIX']
             else:
                 if window_size is None:
                     window_size = get_config('WINDOW_SIZE',
@@ -748,7 +749,7 @@ class ExperimentController(object):
             self._on_every_flip = []
 
     def _convert_units(self, verts, fro, to):
-        """Convert between different screen units"""
+        """Convert between different screen units."""
         check_units(to)
         check_units(fro)
         verts = np.array(np.atleast_2d(verts), dtype=float)
@@ -767,35 +768,35 @@ class ExperimentController(object):
             return verts
 
         # figure out our actual transition, knowing one is 'norm'
-        w_pix = self.window_size_pix[0]
-        h_pix = self.window_size_pix[1]
+        win_w_pix, win_h_pix = self.window_size_pix
+        mon_w_pix, mon_h_pix = self.monitor_size_pix
+        wh_cm = np.array([self._monitor['SCREEN_WIDTH'],
+                          self._monitor['SCREEN_HEIGHT']], float)
         d_cm = self._monitor['SCREEN_DISTANCE']
-        w_cm = self._monitor['SCREEN_WIDTH']
-        h_cm = self._monitor['SCREEN_HEIGHT']
-        w_prop = w_pix / float(self.monitor_size_pix[0])
-        h_prop = h_pix / float(self.monitor_size_pix[1])
+        cm_factors = (self.window_size_pix / self.monitor_size_pix *
+                      wh_cm / 2.)[:, np.newaxis]
         if 'pix' in [to, fro]:
             if 'pix' == to:
                 # norm to pixels
-                x = np.array([[w_pix / 2., 0, w_pix / 2.],
-                              [0, h_pix / 2., h_pix / 2.]])
+                x = np.array([[win_w_pix / 2., 0, win_w_pix / 2.],
+                              [0, win_h_pix / 2., win_h_pix / 2.]])
             else:
                 # pixels to norm
-                x = np.array([[2. / w_pix, 0, -1.],
-                              [0, 2. / h_pix, -1.]])
+                x = np.array([[2. / win_w_pix, 0, -1.],
+                              [0, 2. / win_h_pix, -1.]])
             verts = np.dot(x, np.r_[verts, np.ones((1, verts.shape[1]))])
         elif 'deg' in [to, fro]:
             if 'deg' == to:
                 # norm (window) to norm (whole screen), then to deg
-                x = np.arctan2(verts[0] * w_prop * (w_cm / 2.), d_cm)
-                y = np.arctan2(verts[1] * h_prop * (h_cm / 2.), d_cm)
-                verts = np.rad2deg(np.array([x, y]))
+                verts = np.rad2deg(np.arctan2(verts * cm_factors, d_cm))
             else:
                 # deg to norm (whole screen), to norm (window)
-                verts = np.deg2rad(verts)
-                x = (d_cm * np.tan(verts[0])) / (w_cm / 2.) / w_prop
-                y = (d_cm * np.tan(verts[1])) / (h_cm / 2.) / h_prop
-                verts = np.array([x, y])
+                verts = (d_cm * np.tan(np.deg2rad(verts))) / cm_factors
+        elif 'cm' in [to, fro]:
+            if 'cm' == to:
+                verts = verts * cm_factors
+            else:
+                verts = verts / cm_factors
         else:
             raise KeyError('unknown conversion "{}" to "{}"'.format(fro, to))
         return verts
@@ -963,7 +964,13 @@ class ExperimentController(object):
         gl.glShadeModel(gl.GL_SMOOTH)
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
         v_ = False if os.getenv('_EXPYFUN_WIN_INVISIBLE') == 'true' else True
-        self.set_visible(v_)
+        self.set_visible(v_)  # this is when we set fullscreen
+        # ensure we got the correct window size
+        got_size = win.get_size()
+        if not np.array_equal(got_size, window_size):
+            raise RuntimeError('Requested window size %s but got size %s, '
+                               'is the resolution set incorrectly?'
+                               % (window_size, got_size))
         self._dispatch_events()
 
     def flip(self, when=None):
@@ -1059,7 +1066,7 @@ class ExperimentController(object):
             the window is restored, regardless of what the glClearColor
             had been set to.
         """
-        self._win.set_fullscreen(visible and self._full_screen)
+        self._win.set_fullscreen(self._full_screen)
         self._win.set_visible(visible)
         logger.exp('Expyfun: Set screen visibility {0}'.format(visible))
         if visible and flip:

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -968,8 +968,9 @@ class ExperimentController(object):
         # ensure we got the correct window size
         got_size = win.get_size()
         if not np.array_equal(got_size, window_size):
-            raise RuntimeError('Requested window size %s but got size %s, '
-                               'is the resolution set incorrectly?'
+            raise RuntimeError('Window size requested by config (%s) does not '
+                               'match obtained window size (%s), is the '
+                               'screen resolution set incorrectly?'
                                % (window_size, got_size))
         self._dispatch_events()
 

--- a/expyfun/_utils.py
+++ b/expyfun/_utils.py
@@ -268,9 +268,9 @@ def check_units(units):
     Parameters
     ----------
     units : str
-        Must be ``'norm'``, ``'deg'``, or ``'pix'``.
+        Must be ``'norm'``, ``'deg'``, ``'pix'``, or ``'cm'``.
     """
-    good_units = ['norm', 'pix', 'deg']
+    good_units = ['norm', 'pix', 'deg', 'cm']
     if units not in good_units:
         raise ValueError('"units" must be one of {}, not {}'
                          ''.format(good_units, units))

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -34,9 +34,8 @@ def test_unit_conversions(hide_window, ws):
     kwargs['window_size'] = ws
     with ExperimentController(*std_args, **kwargs) as ec:
         verts = np.random.rand(2, 4)
-        for to in ['norm', 'pix', 'deg']:
-            for fro in ['norm', 'pix', 'deg']:
-                print((ws, to, fro))
+        for to in ['norm', 'pix', 'deg', 'cm']:
+            for fro in ['norm', 'pix', 'deg', 'cm']:
                 v2 = ec._convert_units(verts, fro, to)
                 v2 = ec._convert_units(v2, to, fro)
                 assert_allclose(verts, v2)
@@ -384,13 +383,18 @@ def test_ec(ac, hide_window):
 @pytest.mark.parametrize('screen_num', (None, 0))
 @pytest.mark.parametrize('monitor', (
     None,
-    dict(SCREEN_WIDTH=10, SCREEN_DISTANCE=10, SCREEN_SIZE_PIX=(1000, 1000))))
-def test_screen_monitor(screen_num, monitor):
+    dict(SCREEN_WIDTH=10, SCREEN_DISTANCE=10, SCREEN_SIZE_PIX=(1000, 1000)),
+))
+def test_screen_monitor(screen_num, monitor, hide_window):
     """Test screen and monitor option support."""
     with ExperimentController(
             *std_args, screen_num=screen_num, monitor=monitor,
             **std_kwargs):
         pass
+    full_kwargs = deepcopy(std_kwargs)
+    full_kwargs['full_screen'] = True
+    with pytest.raises(RuntimeError, match='resolution set incorrectly'):
+        ExperimentController(*std_args, **full_kwargs)
     with pytest.raises(TypeError, match='must be a dict'):
         ExperimentController(*std_args, monitor=1, **std_kwargs)
     with pytest.raises(KeyError, match='is missing required keys'):

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ addopts = --showlocals --durations=20 -rs
           --ignore=examples --ignore=tutorials --ignore=doc --ignore=make
           --doctest-modules --doctest-ignore-import-errors -v
 usefixtures = matplotlib_config
+junit_family = xunit2
 # Set this pretty low to ensure we do not by default add really long tests,
 # or make changes that make things a lot slower
 timeout = 5


### PR DESCRIPTION
Adding:
```
"SCREEN_SIZE_PIX": "1920,1200",
```
now ensures that the fullscreen window obtained is this resolution. If I set it to something else (e.g., `800,800`) I get an error message:
```
RuntimeError: Requested window size [800 600] but got size (1920, 1200), is the resolution set incorrectly?
```
Also `sync_test.py` now has a rectangle that is the standard size of a credit card, which hopefully makes it fairly easy to check.(Also you should be able to see if the credit card "looks funny", though you maybe probably see that with the circle.) I've checked and on my screen with proper `expyfun.json` it is indeed the size of a credit card.

@nordme @drammock can you review the code and try it out at least `sync_test.py` on your system(s)?

Closes #404