### PR TITLE
MRG, ENH: Speed up buffering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,11 +70,15 @@ before_install:
         pip install -q joblib mne;
         if [ "${DEPS}" == "pre" ]; then
           pip install -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" --upgrade --pre numpy scipy matplotlib;
-          pip install https://api.github.com/repos/pyglet/pyglet/zipball/master;
+          pip install pyglet;
         else
           pip install pyglet;
         fi;
       fi;
+    # Eventually in "pre" we should do:
+    # pip install https://api.github.com/repos/pyglet/pyglet/zipball/master
+    # But this is known to be problematic...
+
     # Import matplotlib ahead of time so it doesn't affect test timings
     # (e.g., building fc-cache)
     - python -c "import matplotlib.pyplot as plt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,14 @@ matrix:
           packages:
             - ffmpeg
             - libglu1-mesa
+    - os: linux
+      dist: xenial
+      env: _EXPYFUN_SILENT=true DEPS=pre
+      addons:
+        apt:
+          packages:
+            - ffmpeg
+            - libglu1-mesa
     - os: osx
       language: objective-c
     - os: linux
@@ -59,7 +67,13 @@ before_install:
         pip install "pyglet<1.4";
       else
         conda install --yes --quiet pandas h5py;
-        pip install -q joblib pyglet mne;
+        pip install -q joblib mne;
+        if [ "${DEPS}" == "pre" ]; then
+          pip install -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" --upgrade --pre numpy scipy matplotlib;
+          pip install https://api.github.com/repos/pyglet/pyglet/zipball/master;
+        else
+          pip install pyglet;
+        fi;
       fi;
     # Import matplotlib ahead of time so it doesn't affect test timings
     # (e.g., building fc-cache)

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -1660,7 +1660,8 @@ class ExperimentController(object):
             raise RuntimeError('Previous audio must be stopped before loading '
                                'the buffer')
         samples = self._validate_audio(samples)
-        samples *= self._stim_scaler
+        if not np.isclose(self._stim_scaler, 1.):
+            samples = samples * self._stim_scaler
         logger.exp('Expyfun: Loading {} samples to buffer'
                    ''.format(samples.size))
         self._ac.load_buffer(samples)
@@ -1715,7 +1716,7 @@ class ExperimentController(object):
         logger.exp('Expyfun: Audio stopped and reset.')
 
     def set_noise_db(self, new_db):
-        """Set the level of the background noise
+        """Set the level of the background noise.
 
         Parameters
         ----------
@@ -1732,7 +1733,7 @@ class ExperimentController(object):
         self._noise_db = new_db
 
     def set_stim_db(self, new_db):
-        """Set the level of the stimuli
+        """Set the level of the stimuli.
 
         Parameters
         ----------
@@ -1820,8 +1821,9 @@ class ExperimentController(object):
                                ''.format(max_rms, self._stim_rms))
                 logger.warning(warn_string)
 
-        # this will create a copy, so we can modify inplace later!
-        samples = np.array(samples, np.float32)
+        # let's make sure we don't change our version of this array later
+        samples = samples.view()
+        samples.flags['WRITEABLE'] = False
         return samples
 
     def set_rms_checking(self, check_rms):
@@ -2255,13 +2257,15 @@ def _get_dev_db(audio_controller):
             RP2=108.,
             RP2legacy=108.,
             RZ6=114.,
-            pyglet=100.,  # TODO: this value not calibrated, system-dependent
+            # TODO: these values not calibrated, system-dependent
+            pyglet=100.,
+            rtmixer=100.,
             dummy=90.,  # only used for testing
         ).get(audio_controller, None)
     else:
         level = float(level)
     if level is None:
-        logger.warning('Expyfun: Unknown audio controller: stim scaler may '
+        logger.warning('Expyfun: Unknown audio controller %s: stim scaler may '
                        'not work correctly. You may want to remove your '
                        'headphones if this is the first run of your '
                        'experiment.')

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -2267,7 +2267,7 @@ def _get_dev_db(audio_controller):
             # TODO: these values not calibrated, system-dependent
             pyglet=100.,
             rtmixer=100.,
-            dummy=90.,  # only used for testing
+            dummy=100.,  # only used for testing
         ).get(audio_controller, None)
     else:
         level = float(level)
@@ -2275,6 +2275,6 @@ def _get_dev_db(audio_controller):
         logger.warning('Expyfun: Unknown audio controller %s: stim scaler may '
                        'not work correctly. You may want to remove your '
                        'headphones if this is the first run of your '
-                       'experiment.')
-        level = 90  # for untested TDT models
+                       'experiment.' % (audio_controller,))
+        level = 100  # for untested TDT models
     return level

--- a/expyfun/_sound_controllers/_rtmixer.py
+++ b/expyfun/_sound_controllers/_rtmixer.py
@@ -116,8 +116,9 @@ class SoundPlayer(object):
 
     def __init__(self, data, fs=None, loop=False, api=None, name=None,
                  fixed_delay=None, api_options=None):
-        self._data = np.ascontiguousarray(
-            np.clip(np.atleast_2d(data).T, -1, 1).astype(np.float32))
+        data = np.atleast_2d(data).T
+        data = np.asarray(data, np.float32, 'C')
+        self._data = data
         self.loop = bool(loop)
         self._n_samples, n_channels = self._data.shape
         assert n_channels >= 1

--- a/expyfun/_utils.py
+++ b/expyfun/_utils.py
@@ -768,7 +768,7 @@ def running_rms(signal, win_length):
 
 
 def _fix_audio_dims(signal, n_channels):
-    """Make it so a valid audio buffer is in the standard dimensions
+    """Make it so a valid audio buffer is in the standard dimensions.
 
     Parameters
     ----------

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -290,6 +290,9 @@ def test_ec(ac, hide_window):
             ec.load_buffer(click)
         with pytest.warns(UserWarning, match='exceeds stated'):
             ec.load_buffer(noise)
+        if ac != 'tdt':  # too many samples there
+            with pytest.warns(UserWarning, match='slow'):
+                ec.load_buffer(np.zeros(10000001, dtype=np.float32))
 
         ec.stop()
         ec.set_visible()

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -70,11 +70,8 @@ def test_validate_audio(hide_window):
             samples_out = ec._validate_audio(samples_in)
             assert samples_out.shape == samples_in.shape[::-1]
             assert samples_out.dtype == np.float32
-            # transpose that we do will not copy just make a view
+            # ensure that we have not bade a copy, just a view
             assert samples_out.base is samples_in
-            samples_out.flags['WRITEABLE'] = True  # undo our read-only safety
-            samples_out[:] = 1
-            assert_allclose(samples_in.T, samples_out)
 
 
 def test_data_line(hide_window):
@@ -291,7 +288,7 @@ def test_ec(ac, hide_window):
         with pytest.warns(UserWarning, match='exceeds stated'):
             ec.load_buffer(noise)
         if ac != 'tdt':  # too many samples there
-            with pytest.warns(UserWarning, match='slow'):
+            with pytest.warns(UserWarning, match='samples is slow'):
                 ec.load_buffer(np.zeros(10000001, dtype=np.float32))
 
         ec.stop()


### PR DESCRIPTION
@JustinTFleming can you try adding this to your script after EC initialization:
```
ec.set_stim_db(60.)  # assuming you have stim_rms=0.01, the default value
assert ec._stim_scaler == 1.
```
and then see if 1) stimuli load faster than 7 sec, and 2) that they still sound correct? The assertion is necessary to make sure we avoid a scaling later.

This PR should eliminate all copies except the last one (concatenating the sound and the trigger values), there triggering a copy which would be difficult to avoid (we would have to tell `rtmixer` to play two sounds at the same time and hope it did so correctly, which is dicey).

If this ends up being the bottleneck, we could make a new triggering mode where you have to supply the sound stimulus *with the trigger channels zeroed out* (e.g., for 6 channel + 1 trigger channel, you would already supply an array of shape `(7, n_samples`). But let's see how fast we are already with these changes.

Closes #407