### PR TITLE
MRG, FIX: Legacy and wrap

### DIFF
--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -890,7 +890,6 @@ class ExperimentController(object):
     def _setup_event_loop(self):
         from pyglet.app import platform_event_loop, event_loop
         event_loop.has_exit = False
-        event_loop._legacy_setup()
         platform_event_loop.start()
         event_loop.dispatch_event('on_enter')
 

--- a/expyfun/visual/_visual.py
+++ b/expyfun/visual/_visual.py
@@ -105,6 +105,7 @@ class Text(object):
         elif isinstance(width, string_types):
             raise ValueError('"width", if str, must be "auto"')
         self._attr = attr
+        text = text + '\n '  # weird Pyglet bug
         if self._attr:
             preamble = ('{{font_name \'{}\'}}{{font_size {}}}{{color {}}}'
                         '').format(font_name, font_size, _convert_color(color))


### PR DESCRIPTION
1. Removes `_legacy_setup`, which we shouldn't need because it was for old Windows (like Windows 2000) and no longer exists in Pyglet as of Sept 2019.
2. Adds a workaround for text bugs.

For (2), on `master` this code:
```
from expyfun import ExperimentController
with ExperimentController(
        exp_name='CRM corpus example', window_size=(720, 480),
        full_screen=False, participant='foo', session='foo', version='dev',
        output_dir=None) as ec:
    ec.screen_prompt('Report the color and number spoken by the female '
                     'talker.', wrap=True, live_keys=['1'])
```
Produces:

![Screenshot from 2020-03-04 14-23-48](https://user-images.githubusercontent.com/2365790/75915043-c9c1a980-5e23-11ea-8d2f-db4fc6a8b1f3.png)

And on this PR:

![Screenshot from 2020-03-04 14-22-00](https://user-images.githubusercontent.com/2365790/75915014-bca4ba80-5e23-11ea-92fa-d9a19bd2b16b.png)
