### PR TITLE
MRG, ENH: Add move_mouse_to

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_install:
         pip install -q joblib mne;
         if [ "${DEPS}" == "pre" ]; then
           pip install -f "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com" --upgrade --pre numpy scipy matplotlib;
-          pip install https://api.github.com/repos/pyglet/pyglet/zipball/master;
+          pip install https://api.github.com/repos/pyglet/pyglet/zipball/pyglet-1.5-maintenance;
         else
           pip install pyglet;
         fi;

--- a/examples/experiments/mouse.py
+++ b/examples/experiments/mouse.py
@@ -27,10 +27,12 @@ with ExperimentController('MouseDemo', screen_num=0,
                           stim_db=0, noise_db=0, output_dir=None,
                           participant='foo', session='001',
                           version='dev') as ec:
-    ###############
-    # toggle_cursor
+    #################################
+    # toggle_cursor and move_mouse_to
     ec.toggle_cursor(True)
-    ec.screen_prompt('Now you see it.', max_wait=msg_dur, wrap=False)
+    ec.move_mouse_to((0, 0))
+    ec.screen_prompt('Now you see it (centered on the window).',
+                     max_wait=msg_dur, wrap=False)
 
     ec.toggle_cursor(False)
     ec.screen_prompt("Now you don't (maybe--Windows is buggy)",
@@ -59,7 +61,7 @@ with ExperimentController('MouseDemo', screen_num=0,
     clicks = ec.get_clicks()
     ec.screen_prompt('Your clicks:\n%s' % str(clicks), max_wait=msg_dur)
 
-    ###########################
+    ####################
     # get_mouse_position
     ec.screen_prompt('Move the mouse around...', max_wait=msg_dur, wrap=False)
     stop_time = ec.current_time + wait_dur
@@ -70,7 +72,7 @@ with ExperimentController('MouseDemo', screen_num=0,
         ec.check_force_quit()
         ec.flip()
 
-    ###########################
+    ###################
     # wait_for_click_on
     ec.toggle_cursor(False)
     ec.wait_secs(1)

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -1500,6 +1500,18 @@ class ExperimentController(object):
                                                   live_buttons, timestamp,
                                                   relative_to, visible)
 
+    def move_mouse_to(self, pos, units='norm'):
+        """Move the mouse position to the specified position.
+
+        Parameters
+        ----------
+        pos : array-like
+            2-element array-like with X and Y.
+        units : str
+            Units to use. See ``check_units`` for options.
+        """
+        self._mouse_handler._move_to(pos, units)
+
     def wait_for_clicks(self, max_wait=np.inf, min_wait=0.0, live_buttons=None,
                         timestamp=True, relative_to=None, visible=None):
         """Returns all clicks between min_wait and max_wait.
@@ -1794,7 +1806,9 @@ class ExperimentController(object):
         if self._fs_mismatch and not self._suppress_resamp:
             logger.warning('Expyfun: Resampling {} seconds of audio'
                            ''.format(round(len(samples) / self.stim_fs, 2)))
-            from mne.filter import resample
+            with warnings.catch_warnings(record=True):
+                warnings.simplefilter('ignore')
+                from mne.filter import resample
             if samples.size:
                 samples = resample(
                     samples.astype(np.float64), self.fs, self.stim_fs,

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -923,7 +923,8 @@ class ExperimentController(object):
         if os.getenv('TRAVIS') == 'true':
             del config_kwargs['samples'], config_kwargs['sample_buffers']
         self._full_screen = full_screen
-        win_kwargs = dict(width=window_size[0], height=window_size[1],
+        win_kwargs = dict(width=int(window_size[0]),
+                          height=int(window_size[1]),
                           caption=exp_name, fullscreen=False,
                           screen=screen, style='borderless', visible=False,
                           config=pyglet.gl.Config(**config_kwargs))

--- a/expyfun/_input_controllers.py
+++ b/expyfun/_input_controllers.py
@@ -554,7 +554,7 @@ class Mouse(object):
             point = POINT()
             point.x = x
             point.y = y
-            _user32.ClientToScreen(self.ec._hwnd, byref(point))
+            _user32.ClientToScreen(self.ec.window._hwnd, byref(point))
             # Move the mouse
             _user32.SetCursorPos(point.x, point.y)
         else:

--- a/expyfun/_input_controllers.py
+++ b/expyfun/_input_controllers.py
@@ -519,11 +519,10 @@ class Mouse(object):
         # adapted from pyautogui (BSD)
         x, y = self.ec._convert_units(np.array(
             [pos]).T, units, 'pix')[:, 0].round().astype(int)
-        # The "y" we use is inverted relative to XWindow
+        # The "y" we use is inverted relative to the OSes
         y = self.ec.window.height - y
         if sys.platform == 'darwin':
             from pyglet.libs.darwin.cocoapy import quartz, CGPoint, CGRect
-            from ctypes import c_void_p
             # Convert from window to global
             view, window = self.ec.window._nsview, self.ec.window._nswindow
             point = CGPoint()
@@ -547,8 +546,8 @@ class Mouse(object):
             # func.restype = c_void_p
             # func.argtypes = [...]
             # func(kCGHIDEventTap, event)
-            #time.sleep(0.001)
-            #quartz.CFRelease(event)
+            # time.sleep(0.001)
+            # quartz.CFRelease(event)
         elif sys.platform.startswith('win'):
             # Convert from window to global
             from pyglet.window.win32 import POINT, _user32, byref

--- a/expyfun/_input_controllers.py
+++ b/expyfun/_input_controllers.py
@@ -558,7 +558,7 @@ class Mouse(object):
             # Move the mouse
             _user32.SetCursorPos(point.x, point.y)
         else:
-            # https://stackoverflow.com/questions/2433447/how-to-set-mouse-cursor-position-in-c-on-linux/2433488  # noqa
+            # https://stackoverflow.com/questions/2433447
             from pyglet.libs.x11.xlib import (XWarpPointer, XFlush,
                                               XSelectInput, KeyReleaseMask)
             display, window = self.ec.window._x_display, self.ec.window._window

--- a/expyfun/_tdt_controller.py
+++ b/expyfun/_tdt_controller.py
@@ -379,7 +379,7 @@ class TDTController(Keyboard):  # lgtm [py/missing-call-to-init]
     @property
     def fs(self):
         """Playback frequency of the audio (samples / second)."""
-        return np.float(self.rpcox.GetSFreq())
+        return np.float64(self.rpcox.GetSFreq())
 
     @property
     def model(self):

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -385,6 +385,7 @@ def test_ec(ac, hide_window):
         ec.get_clicks()
         ec.toggle_cursor(False)
         ec.toggle_cursor(True, True)
+        ec.move_mouse_to((0, 0))  # center of the window
         ec.wait_secs(0.001)
         print(ec.id_types)
         print(ec.stim_db)


### PR DESCRIPTION
Tested on Linux and macOS, Windows in progress. @drammock feel free to review and if you're happy I'll merge once it works on Windows.

cc @LiesbethGijbels this will allow you just to use `ec.move_mouse_to((0, 0))` instead of using `pyautogui`.