### PR TITLE
ENH: Allow triggering after onset

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
       - run: pip install --quiet --upgrade --user pip
       - run: pip install --quiet --upgrade --user numpy scipy matplotlib sphinx pillow pandas h5py mne pyglet psutil sphinx_bootstrap_theme sphinx_fontawesome numpydoc https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master
       - run: python -c "import mne; mne.sys_info()"
+      - run: python -c "import pyglet; print(pyglet.version)"
       - run: python setup.py develop --user
       - run: cd doc && make html
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ before_install:
           pip install pyglet;
         fi;
       fi;
+    - python -c "import pyglet; print(pyglet.version)"
     # Import matplotlib ahead of time so it doesn't affect test timings
     # (e.g., building fc-cache)
     - python -c "import matplotlib.pyplot as plt"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ install:
   - "python --version"
   - "pip install -q numpy scipy matplotlib coverage setuptools h5py pandas pytest pytest-cov pytest-timeout pytest-xdist codecov pyglet mne tdtpy joblib numpydoc pillow"
   - "python -c \"import mne; mne.sys_info()\""
+  - "python -c \"import pyglet; print(pyglet.version)\""
   # Get a virtual sound card / VBAudioVACWDM device
   - "git clone --depth 1 git://github.com/LABSN/sound-ci-helpers.git"
   - "powershell sound-ci-helpers/windows/setup_sound.ps1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ platform:
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python --version"
-  - "pip install -q numpy scipy matplotlib coverage setuptools h5py pandas pytest pytest-cov pytest-timeout pytest-xdist codecov pyglet mne tdtpy joblib numpydoc pillow"
+  - "pip install -q numpy scipy matplotlib coverage setuptools h5py pandas pytest pytest-cov pytest-timeout pytest-xdist codecov \"pyglet!=1.5.16\" mne tdtpy joblib numpydoc pillow"
   - "python -c \"import mne; mne.sys_info()\""
   - "python -c \"import pyglet; print(pyglet.version)\""
   # Get a virtual sound card / VBAudioVACWDM device

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ jobs:
       pip install -q numpy scipy matplotlib coverage setuptools h5py pandas pytest pytest-cov pytest-timeout pytest-xdist codecov pyglet pyglet-ffmpeg mne tdtpy joblib numpydoc pillow
       python -c "import mne; mne.sys_info()"
       python -c "import matplotlib.pyplot as plt"
+      python -c "import pyglet; print(pyglet.version)"
     displayName: 'Install pip dependencies'
   - powershell: |
       git clone --depth 1 git://github.com/LABSN/sound-ci-helpers.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
       addToPath: true
   - powershell: |
       pip install --upgrade numpy scipy vtk
-      pip install -q numpy scipy matplotlib coverage setuptools h5py pandas pytest pytest-cov pytest-timeout pytest-xdist codecov pyglet pyglet-ffmpeg mne tdtpy joblib numpydoc pillow
+      pip install -q numpy scipy matplotlib coverage setuptools h5py pandas pytest pytest-cov pytest-timeout pytest-xdist codecov "pyglet!=1.5.15" pyglet-ffmpeg mne tdtpy joblib numpydoc pillow
       python -c "import mne; mne.sys_info()"
       python -c "import matplotlib.pyplot as plt"
       python -c "import pyglet; print(pyglet.version)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
       addToPath: true
   - powershell: |
       pip install --upgrade numpy scipy vtk
-      pip install -q numpy scipy matplotlib coverage setuptools h5py pandas pytest pytest-cov pytest-timeout pytest-xdist codecov "pyglet!=1.5.15" pyglet-ffmpeg mne tdtpy joblib numpydoc pillow
+      pip install -q numpy scipy matplotlib coverage setuptools h5py pandas pytest pytest-cov pytest-timeout pytest-xdist codecov "pyglet!=1.5.16" pyglet-ffmpeg mne tdtpy joblib numpydoc pillow
       python -c "import mne; mne.sys_info()"
       python -c "import matplotlib.pyplot as plt"
       python -c "import pyglet; print(pyglet.version)"

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -98,8 +98,8 @@ class ExperimentController(object):
         If ``None``, the type will be read from the system configuration file.
         If a string, must be 'dummy', 'parallel', 'sound_card', or 'tdt'.
         By default the mode is 'dummy', since setting up the parallel port
-        can be a pain. Can also be a dict with entries 'type' ('parallel'),
-        and 'address' (None).
+        can be a pain. Can also be a dict with entries 'TYPE' ('parallel'),
+        and 'TRIGGER_ADDRESS' (None).
     session : str | None
         If ``None``, a GUI will be used to acquire this information.
     check_rms : str | None
@@ -420,7 +420,7 @@ class ExperimentController(object):
             if trigger_controller is None:
                 trigger_controller = get_config('TRIGGER_CONTROLLER', 'dummy')
             if isinstance(trigger_controller, string_types):
-                trigger_controller = dict(type=trigger_controller)
+                trigger_controller = dict(TYPE=trigger_controller)
             assert isinstance(trigger_controller, dict)
             trigger_controller = trigger_controller.copy()
             known_keys = ('TYPE',)

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -421,14 +421,21 @@ class ExperimentController(object):
                 trigger_controller = get_config('TRIGGER_CONTROLLER', 'dummy')
             if isinstance(trigger_controller, string_types):
                 trigger_controller = dict(type=trigger_controller)
-            logger.info('Expyfun: Initializing {} triggering mode'
-                        ''.format(trigger_controller['type']))
-            if trigger_controller['type'] == 'tdt':
+            assert isinstance(trigger_controller, dict)
+            trigger_controller = trigger_controller.copy()
+            known_keys = ('TYPE',)
+            if set(trigger_controller) != set(known_keys):
+                raise ValueError(
+                    'Unknown keys for trigger_controller, must be '
+                    f'{known_keys}, got {set(trigger_controller)}')
+            logger.info(f'Expyfun: Initializing {trigger_controller["TYPE"]} '
+                        'triggering mode')
+            if trigger_controller['TYPE'] == 'tdt':
                 if not isinstance(self._ac, TDTController):
                     raise ValueError('trigger_controller can only be "tdt" if '
                                      'tdt is used for audio')
                 self._tc = self._ac
-            elif trigger_controller['type'] == 'sound_card':
+            elif trigger_controller['TYPE'] == 'sound_card':
                 if not isinstance(self._ac, SoundCardController):
                     raise ValueError('trigger_controller can only be '
                                      '"sound_card" if the sound card is '
@@ -438,23 +445,21 @@ class ExperimentController(object):
                                      'when SOUND_CARD_TRIGGER_CHANNELS is '
                                      'zero')
                 self._tc = self._ac
-            elif trigger_controller['type'] in ['parallel', 'dummy']:
-                if 'address' not in trigger_controller:
-                    addr = get_config('TRIGGER_ADDRESS')
-                    trigger_controller['address'] = addr
+            elif trigger_controller['TYPE'] in ['parallel', 'dummy']:
+                addr = trigger_controller.get(
+                    'TRIGGER_ADDRESS', get_config('TRIGGER_ADDRESS', None))
                 self._tc = ParallelTrigger(
-                    trigger_controller['type'],
-                    trigger_controller.get('address'),
+                    trigger_controller['TYPE'], addr,
                     trigger_duration, ec=self)
                 self._extra_cleanup_fun.insert(0, self._tc.close)
                 # The TDT always stamps "1" on stimulus onset. Here we need
                 # to manually mimic that behavior.
                 self._ofp_critical_funs.insert(
-                    0, lambda: self._stamp_ttl_triggers([1], False))
+                    0, lambda: self._stamp_ttl_triggers([1], False, False))
             else:
                 raise ValueError('trigger_controller type must be '
                                  '"parallel", "dummy", "sound_card", or "tdt",'
-                                 'got {0}'.format(trigger_controller['type']))
+                                 'got {0}'.format(trigger_controller['TYPE']))
             self._id_call_dict['ttl_id'] = self._stamp_binary_id
 
             # other basic components
@@ -2072,7 +2077,7 @@ class ExperimentController(object):
         if not np.all(np.in1d(id_, [0, 1])):
             raise ValueError('All values of id must be 0 or 1')
         id_ = (id_.astype(int) + 1) << 2  # 0, 1 -> 4, 8
-        self._stamp_ttl_triggers(id_, wait_for_last)
+        self._stamp_ttl_triggers(id_, wait_for_last, True)
 
     def stamp_triggers(self, ids, check='binary', wait_for_last=True):
         """Stamp binary values
@@ -2087,6 +2092,7 @@ class ExperimentController(object):
             1 and 15.
         wait_for_last : bool
             If True, wait for last trigger to be stamped before returning.
+            If False, don't wait at all (if possible).
 
         Notes
         -----
@@ -2107,11 +2113,12 @@ class ExperimentController(object):
             if not all(id_ in _vals for id_ in ids):
                 raise ValueError('with check="binary", ids must all be '
                                  '1, 2, 4, or 8: {0}'.format(ids))
-        self._stamp_ttl_triggers(ids, wait_for_last)
+        self._stamp_ttl_triggers(ids, wait_for_last, False)
 
-    def _stamp_ttl_triggers(self, ids, wait_for_last):
+    def _stamp_ttl_triggers(self, ids, wait_for_last, is_trial_id):
         logger.exp('Stamping TTL triggers: %s', ids)
-        self._tc.stamp_triggers(ids, wait_for_last=wait_for_last)
+        self._tc.stamp_triggers(
+            ids, wait_for_last=wait_for_last, is_trial_id=is_trial_id)
         self.flush()
 
     def flush(self):

--- a/expyfun/_tdt_controller.py
+++ b/expyfun/_tdt_controller.py
@@ -288,7 +288,8 @@ class TDTController(Keyboard):  # lgtm [py/missing-call-to-init]
         logger.info('Expyfun: Setting TDT trigger delay to %s' % delay_trig)
 
 # ############################### TRIGGER METHODS #############################
-    def stamp_triggers(self, triggers, delay=None, wait_for_last=True):
+    def stamp_triggers(self, triggers, delay=None, wait_for_last=True,
+                       is_trial_id=False):
         """Stamp a list of triggers with a given inter-trigger delay.
 
         Parameters
@@ -301,6 +302,8 @@ class TDTController(Keyboard):  # lgtm [py/missing-call-to-init]
             If None, will use twice the trigger duration (50% duty cycle).
         wait_for_last : bool
             If True, wait for last trigger to be stamped before returning.
+        is_trial_id : bool
+            No effect for this controller.
         """
         if delay is None:
             delay = 0.02  # we have a fixed trig duration of 0.01

--- a/expyfun/_trigger_controllers.py
+++ b/expyfun/_trigger_controllers.py
@@ -106,7 +106,8 @@ class ParallelTrigger(object):
         self.ec.wait_secs(self.trigger_duration)
         self._set_data(0)
 
-    def stamp_triggers(self, triggers, delay=None, wait_for_last=True):
+    def stamp_triggers(self, triggers, delay=None, wait_for_last=True,
+                       is_trial_id=False):
         """Stamp a list of triggers with a given inter-trigger delay.
 
         Parameters
@@ -119,6 +120,8 @@ class ParallelTrigger(object):
             If None, will use twice the trigger duration (50% duty cycle).
         wait_for_last : bool
             If True, wait for last trigger to be stamped before returning.
+        is_trial_id : bool
+            No effect for this trigger controller.
         """
         if delay is None:
             delay = 2 * self.trigger_duration

--- a/expyfun/_utils.py
+++ b/expyfun/_utils.py
@@ -13,6 +13,7 @@ import os
 import os.path as op
 import inspect
 import sys
+import time
 import tempfile
 import traceback
 import ssl
@@ -588,6 +589,7 @@ known_config_types = ('RESPONSE_DEVICE',
                       'SOUND_CARD_TRIGGER_CHANNELS',
                       'SOUND_CARD_TRIGGER_INSERTION',
                       'SOUND_CARD_TRIGGER_SCALE',
+                      'SOUND_CARD_TRIGGER_ID_AFTER_ONSET',
                       'TDT_CIRCUIT_PATH',
                       'TDT_DELAY',
                       'TDT_INTERFACE',
@@ -765,10 +767,13 @@ def _wait_secs(secs, ec=None):
         while (clock() - t0) < secs:
             ec._dispatch_events()
             ec.check_force_quit()
+            time.sleep(0.0001)
     else:
         wins = _get_display().get_windows()
-        for win in wins:
-            win.dispatch_events()
+        while (clock() - t0) < secs:
+            for win in wins:
+                win.dispatch_events()
+            time.sleep(0.0001)
 
 
 def running_rms(signal, win_length):


### PR DESCRIPTION
1. Add `SOUND_CARD_TRIGGER_ID_AFTER_ONSET` config var to allow stamping the TTL IDs after the 1 trigger so that a single sound can be played. Should help with rtmixer/portaudio fragility when sounds are stopped and started in close proximity.
2. Change `stamp_triggers` for the sound controller to return as quickly as possible when `wait_for_last=False`. We had made it wait until all but the last trigger was stamped to be consistent with TDT and parallel triggers. It seems better not to do this if we don't need to -- it decreases the uniformity of our approach across platforms, but makes the sound card platform (probably the way of the future) work better.
3. Fix `wait_secs` when not used in an `ec` context. Probably doesn't matter but I noticed this bug was introduced in #399.