### PR TITLE
CI: Test video explicitly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,6 +98,9 @@ stages:
         python setup.py develop
       displayName: 'Install'
     - bash: |
+        python examples/stimuli/simple_video.py
+      displayName: 'Ensure that video works'
+    - bash: |
         pytest --tb=short --cov=expyfun expyfun
       displayName: 'Run tests'
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
         if [[ "$PYTHON_VERSION" == "3.9" ]]; then
           # Until https://github.com/pyglet/pyglet/pull/516 is reverted or fixed, we need to use an older one
           # pip install --user --upgrade https://github.com/pyglet/pyglet/zipball/pyglet-1.5-maintenance
-          pip install --user --upgrade https://github.com/pyglet/pyglet/zipball/69735d0ba65728f7093437149750b52c1fd1cd95
+          pip install --user --upgrade https://github.com/caffeinepills/pyglet/zipball/wic_file_object
         else
           pip install --user --upgrade "pyglet!=1.5.16"
         fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
         if [[ "$PYTHON_VERSION" == "3.9" ]]; then
           # Until https://github.com/pyglet/pyglet/pull/516 is reverted or fixed, we need to use an older one
           # pip install --user --upgrade https://github.com/pyglet/pyglet/zipball/pyglet-1.5-maintenance
-          pip install --user --upgrade https://github.com/caffeinepills/pyglet/zipball/wic_file_object
+          pip install --user --upgrade https://github.com/pyglet/pyglet/zipball/69735d0ba65728f7093437149750b52c1fd1cd95
         else
           pip install --user --upgrade "pyglet!=1.5.16"
         fi
@@ -97,9 +97,6 @@ stages:
     - bash: |
         python setup.py develop
       displayName: 'Install'
-    - bash: |
-        python examples/stimuli/simple_video.py
-      displayName: 'Ensure that video works'
     - bash: |
         pytest --tb=short --cov=expyfun expyfun
       displayName: 'Run tests'

--- a/examples/stimuli/advanced_video.py
+++ b/examples/stimuli/advanced_video.py
@@ -20,7 +20,7 @@ movie_path = fetch_data_file('video/example-video.mp4')
 
 ec_args = dict(exp_name='advanced video example', window_size=(720, 480),
                full_screen=False, participant='foo', session='foo',
-               version='dev', enable_video=True, output_dir=None)
+               version='dev', output_dir=None)
 colors = [x for x in 'rgbcmyk']
 
 with ExperimentController(**ec_args) as ec:

--- a/examples/stimuli/simple_video.py
+++ b/examples/stimuli/simple_video.py
@@ -19,7 +19,7 @@ movie_path = fetch_data_file('video/example-video.mp4')
 
 ec_args = dict(exp_name='simple video example', window_size=(720, 480),
                full_screen=False, participant='foo', session='foo',
-               version='dev', enable_video=True, output_dir=None)
+               version='dev', output_dir=None)
 
 with ExperimentController(**ec_args) as ec:
     ec.load_video(movie_path)
@@ -28,9 +28,9 @@ with ExperimentController(**ec_args) as ec:
     while not ec.video.finished:
         if ec.video.playing:
             fliptime = ec.flip()
-        screenshot = ec.screenshot()
         if building_doc:
             break
+    screenshot = ec.screenshot()
     ec.delete_video()
     ec.flip()
     ec.screen_prompt('video over', max_wait=1.)

--- a/examples/stimuli/simple_video.py
+++ b/examples/stimuli/simple_video.py
@@ -20,6 +20,7 @@ movie_path = fetch_data_file('video/example-video.mp4')
 ec_args = dict(exp_name='simple video example', window_size=(720, 480),
                full_screen=False, participant='foo', session='foo',
                version='dev', output_dir=None)
+screenshot = None
 
 with ExperimentController(**ec_args) as ec:
     ec.load_video(movie_path)
@@ -28,9 +29,10 @@ with ExperimentController(**ec_args) as ec:
     while not ec.video.finished:
         if ec.video.playing:
             fliptime = ec.flip()
+        if screenshot is None:
+            screenshot = ec.screenshot()
         if building_doc:
             break
-    screenshot = ec.screenshot()
     ec.delete_video()
     ec.flip()
     ec.screen_prompt('video over', max_wait=1.)

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -114,8 +114,6 @@ class ExperimentController(object):
         the expected version of the expyfun codebase is being used when running
         experiments. To override version checking (e.g., during development)
         use ``version='dev'``.
-    enable_video : bool
-        If True, enable video mode.
     safe_flipping : bool | None
         If False, do not use ``glFinish`` when flipping. This can restore
         60 Hz on Linux systems where 30 Hz framerates occur, but the timing
@@ -150,7 +148,7 @@ class ExperimentController(object):
                  full_screen=True, force_quit=None, participant=None,
                  monitor=None, trigger_controller=None, session=None,
                  check_rms='windowed', suppress_resamp=False, version=None,
-                 enable_video=False, safe_flipping=None, n_channels=2,
+                 safe_flipping=None, n_channels=2,
                  trigger_duration=0.01, joystick=False, verbose=None):
         # initialize some values
         self._stim_fs = stim_fs
@@ -159,7 +157,6 @@ class ExperimentController(object):
         self._noise_db = noise_db
         self._stim_scaler = None
         self._suppress_resamp = suppress_resamp
-        self._enable_video = enable_video
         self.video = None
         self._bgcolor = _convert_color('k')
         # placeholder for extra actions to do on flip-and-play
@@ -638,9 +635,8 @@ class ExperimentController(object):
         appropriate background color.
         """
         from pyglet import gl
-        if not self._enable_video:
-            # we go a little over here to be safe from round-off errors
-            Rectangle(self, pos=[0, 0, 2.1, 2.1], fill_color=color).draw()
+        # we go a little over here to be safe from round-off errors
+        Rectangle(self, pos=[0, 0, 2.1, 2.1], fill_color=color).draw()
         self._bgcolor = _convert_color(color)
         gl.glClearColor(*[c / 255. for c in self._bgcolor])
 
@@ -1028,8 +1024,7 @@ class ExperimentController(object):
         # this waits until everything is called, including last draw
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
         gl.glBegin(gl.GL_POINTS)
-        if not self._enable_video:
-            gl.glColor4f(0, 0, 0, 0)
+        gl.glColor4f(0, 0, 0, 0)
         gl.glVertex2i(10, 10)
         gl.glEnd()
         if self.safe_flipping:

--- a/expyfun/analyze/tests/test_analyze_functions.py
+++ b/expyfun/analyze/tests/test_analyze_functions.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 try:
@@ -159,7 +161,8 @@ def test_sigmoid():
     assert np.all(np.logical_and(y <= 1, y >= 0))
     p = ea.fit_sigmoid(x, y)
     assert_allclose(p, p0, atol=1e-4, rtol=1e-4)
-    with pytest.warns(None):  # scipy convergence
+    with warnings.catch_warnings(record=True):  # scipy convergence
+        warnings.simplefilter('ignore')
         p = ea.fit_sigmoid(x, y, (0, 1, None, None), ('upper', 'lower'))
     assert_allclose(p, p0, atol=1e-4, rtol=1e-4)
 

--- a/expyfun/analyze/tests/test_viz.py
+++ b/expyfun/analyze/tests/test_viz.py
@@ -1,5 +1,7 @@
 import numpy as np
 from os import path as op
+import warnings
+
 import pytest
 from numpy.testing import assert_equal
 
@@ -104,7 +106,8 @@ def test_barplot_multiple():
     extns = ['pdf']  # jpg, tif not supported; 'png', 'raw', 'svg' not tested
     for ext in extns:
         fname = op.join(temp_dir, 'temp.' + ext)
-        with pytest.warns(None) as w:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             ea.barplot(tmp, groups=[[0, 1, 2], [3]], err_bars='sd', axis=0,
                        fname=fname)
             plt.close()

--- a/expyfun/tests/test_docstring_parameters.py
+++ b/expyfun/tests/test_docstring_parameters.py
@@ -5,6 +5,7 @@ from pkgutil import walk_packages
 import re
 import sys
 from unittest import SkipTest
+import warnings
 
 import pytest
 
@@ -72,7 +73,8 @@ def check_parameters_match(func, doc=None, cls=None):
         args = args[1:]
 
     if doc is None:
-        with pytest.warns(None) as w:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             try:
                 doc = docscrape.FunctionDoc(func)
             except Exception as exp:
@@ -114,7 +116,8 @@ def test_docstring_parameters():
     from numpydoc import docscrape
     incorrect = []
     for name in public_modules:
-        with pytest.warns(None):  # traits warnings
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('ignore')
             module = __import__(name, globals())
         for submod in name.split('.')[1:]:
             module = getattr(module, submod)
@@ -122,7 +125,8 @@ def test_docstring_parameters():
         for cname, cls in classes:
             if cname.startswith('_') and cname not in _doc_special_members:
                 continue
-            with pytest.warns(None) as w:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
                 cdoc = docscrape.ClassDoc(cls)
             for ww in w:
                 if 'Using or importing the ABCs' not in str(ww.message):
@@ -154,7 +158,8 @@ def test_tabs():
         if not ispkg and modname not in ignore:
             # mod = importlib.import_module(modname)  # not py26 compatible!
             try:
-                with pytest.warns(None):
+                with warnings.catch_warnings(record=True):
+                    warnings.simplefilter('ignore')
                     __import__(modname)
             except Exception:  # can't import properly
                 continue
@@ -206,7 +211,8 @@ def test_documented():
 
     missing = []
     for name in public_modules_:
-        with pytest.warns(None):  # traits warnings
+        with warnings.catch_warnings(record=True):  # traits warnings
+            warnings.simplefilter('ignore')
             module = __import__(name, globals())
         for submod in name.split('.')[1:]:
             module = getattr(module, submod)

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -18,7 +18,7 @@ from expyfun._sound_controllers._sound_controller import _SOUND_CARD_KEYS
 from expyfun.stimuli import get_tdt_rates
 
 std_args = ['test']  # experiment name
-std_kwargs = dict(output_dir=None, full_screen=False, window_size=(1, 1),
+std_kwargs = dict(output_dir=None, full_screen=False, window_size=(4, 4),
                   participant='foo', session='01', stim_db=0.0, noise_db=0.0,
                   verbose=True, version='dev')
 

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -555,6 +555,7 @@ def test_background_color(hide_window):
     """Test setting background color"""
     with ExperimentController(*std_args, participant='foo', session='01',
                               output_dir=None, version='dev') as ec:
+        print((ec.window.width, ec.window.height))
         ec.set_background_color('red')
         ss = ec.screenshot()[:, :, :3]
         red_mask = (ss == [255, 0, 0]).all(axis=-1)

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -550,6 +550,7 @@ def test_mouse_clicks(hide_window):
 
 
 @requires_opengl21
+@pytest.mark.timeout(30)
 def test_background_color(hide_window):
     """Test setting background color"""
     with ExperimentController(*std_args, participant='foo', session='01',

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from functools import partial
 import sys
+import warnings
 
 import numpy as np
 from numpy.testing import assert_equal
@@ -18,7 +19,7 @@ from expyfun._sound_controllers._sound_controller import _SOUND_CARD_KEYS
 from expyfun.stimuli import get_tdt_rates
 
 std_args = ['test']  # experiment name
-std_kwargs = dict(output_dir=None, full_screen=False, window_size=(4, 4),
+std_kwargs = dict(output_dir=None, full_screen=False, window_size=(8, 8),
                   participant='foo', session='01', stim_db=0.0, noise_db=0.0,
                   verbose=True, version='dev')
 
@@ -190,12 +191,14 @@ def test_ec(ac, hide_window, monkeypatch):
         _check_skip_backend(ac)
         rd, tc, fs = 'keyboard', 'dummy', 44100
     for suppress in (True, False):
-        with pytest.warns(None) as w:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             with ExperimentController(
                     *std_args, audio_controller=ac, response_device=rd,
                     trigger_controller=tc, stim_fs=100.,
                     suppress_resamp=suppress, **std_kwargs) as ec:
                 pass
+        w = [ww for ww in w if 'TDT is in dummy mode' in str(ww.message)]
         assert len(w) == (1 if ac == 'tdt' else 0)
     SAFE_DELAY = 0.2
     with ExperimentController(

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -558,7 +558,6 @@ def test_background_color(hide_window):
     """Test setting background color"""
     with ExperimentController(*std_args, participant='foo', session='01',
                               output_dir=None, version='dev') as ec:
-        print((ec.window.width, ec.window.height))
         ec.set_background_color('red')
         ss = ec.screenshot()[:, :, :3]
         red_mask = (ss == [255, 0, 0]).all(axis=-1)

--- a/expyfun/tests/test_version.py
+++ b/expyfun/tests/test_version.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 from os import path as op
+import warnings
 
 import pytest
 
@@ -30,7 +31,8 @@ def test_version_assertions():
             pytest.raises(RuntimeError, download_version, 'x' * 7, tempdir)
             ex_dir = op.join(tempdir, 'expyfun')
             assert not op.isdir(ex_dir)
-            with pytest.warns(None):  # Sometimes warns
+            with warnings.catch_warnings(record=True):  # Sometimes warns
+                warnings.simplefilter('ignore')
                 download_version(want_version, tempdir)
             assert op.isdir(ex_dir)
             assert op.isfile(op.join(ex_dir, '__init__.py'))

--- a/expyfun/visual/tests/test_visuals.py
+++ b/expyfun/visual/tests/test_visuals.py
@@ -95,7 +95,7 @@ def test_visuals(hide_window):
 @requires_video()
 def test_video(hide_window):
     """Test EC video methods."""
-    std_kwargs.update(dict(enable_video=True, window_size=(640, 480)))
+    std_kwargs.update(dict(window_size=(640, 480)))
     video_path = fetch_data_file('video/example-video.mp4')
     with ExperimentController('test', **std_kwargs) as ec:
         ec.load_video(video_path)

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,8 @@ filterwarnings =
     always:.*may indicate binary incompatibility.*:
     ignore:.*Cannot change thread mode after it is set.*:UserWarning
     ignore:.*distutils Version classes are deprecated.*:DeprecationWarning
+    ignore:.*distutils\.sysconfig module is deprecated.*:DeprecationWarning
+    ignore:.*isSet\(\) is deprecated.*:DeprecationWarning
 
 [flake8]
 exclude = __init__.py,decorator.py,ndarraysource.py


### PR DESCRIPTION
@drammock looking at Azure logs like this I don't see any skips because of missing `ffmpeg`, which suggests that things work there:

https://dev.azure.com/LABSN/expyfun/_build/results?buildId=328&view=logs&jobId=db093384-e8eb-5bcc-f0a9-2a8f5e4220af&j=db093384-e8eb-5bcc-f0a9-2a8f5e4220af&t=b83569e5-86aa-5f40-c5f2-cb2c66a2c238

This PR explicitly adds a test that the video example runs. On my Linux machine, it pops up, the video plays, and then it exits. The same should in principle happen on Windows. Let's see...

If it does, @drammock feel free to play with your local setup / deps until it works, too, and push to this PR to update any instructions.

Closes #436