### PR TITLE
BUG: Fix video on Windows for Pyglet > 1.3

### DIFF
--- a/examples/stimuli/simple_video.py
+++ b/examples/stimuli/simple_video.py
@@ -33,6 +33,7 @@ with ExperimentController(**ec_args) as ec:
             screenshot = ec.screenshot()
         if building_doc:
             break
+        ec.check_force_quit()
     ec.delete_video()
     ec.flip()
     ec.screen_prompt('video over', max_wait=1.)

--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -890,13 +890,13 @@ class ExperimentController(object):
         self.video = None
 
 # ############################### PYGLET EVENTS ###############################
+# https://pyglet.readthedocs.io/en/latest/programming_guide/eventloop.html#dispatching-events-manually  # noqa
 
     def _setup_event_loop(self):
         from pyglet.app import platform_event_loop, event_loop
         event_loop.has_exit = False
         platform_event_loop.start()
         event_loop.dispatch_event('on_enter')
-
         event_loop.is_running = True
         self._extra_cleanup_fun.append(self._end_event_loop)
         # This is when Pyglet calls:
@@ -904,11 +904,12 @@ class ExperimentController(object):
         # which is a while loop with the contents of our dispatch_events.
 
     def _dispatch_events(self):
-        from pyglet.app import platform_event_loop
+        import pyglet
+        pyglet.clock.tick()
         self._win.dispatch_events()
         # timeout = self._event_loop.idle()
         timeout = 0
-        platform_event_loop.step(timeout)
+        pyglet.app.platform_event_loop.step(timeout)
 
     def _end_event_loop(self):
         from pyglet.app import platform_event_loop, event_loop

--- a/expyfun/visual/_visual.py
+++ b/expyfun/visual/_visual.py
@@ -1160,6 +1160,8 @@ class Video(object):
         gl.glBindBuffer(gl.GL_ARRAY_BUFFER, 0)
         gl.glUseProgram(0)
 
+        self._manual_update = not _new_pyglet()
+
     def play(self, auto_draw=True):
         """Play video from current position.
 
@@ -1295,7 +1297,8 @@ class Video(object):
 
     def draw(self):
         """Draw the video texture to the screen buffer."""
-        self._player.update_texture()
+        if self._manual_update:
+            self._player.update_texture()
         # detect end-of-stream to prevent pyglet from hanging:
         if not self._eos:
             if self._visible:

--- a/expyfun/visual/_visual.py
+++ b/expyfun/visual/_visual.py
@@ -1080,6 +1080,7 @@ varying vec2 v_texcoord;
 void main()
 {
     gl_FragColor = texture2DRect(u_texture, v_texcoord);
+    gl_FragColor.a = 1.0;
 }
 '''
 

--- a/expyfun/visual/_visual.py
+++ b/expyfun/visual/_visual.py
@@ -1160,8 +1160,6 @@ class Video(object):
         gl.glBindBuffer(gl.GL_ARRAY_BUFFER, 0)
         gl.glUseProgram(0)
 
-        self._manual_update = not _new_pyglet()
-
     def play(self, auto_draw=True):
         """Play video from current position.
 
@@ -1297,8 +1295,7 @@ class Video(object):
 
     def draw(self):
         """Draw the video texture to the screen buffer."""
-        if self._manual_update:
-            self._player.update_texture()
+        self._player.update_texture()
         # detect end-of-stream to prevent pyglet from hanging:
         if not self._eos:
             if self._visible:


### PR DESCRIPTION
We had two problems, I think:

1. We need to call `pyglet.clock.tick(poll=True)` to get the video to advance, and 
2. The alpha for the video is messed up on Windows

(2) has been opened upstream as a Pyglet bug (https://github.com/pyglet/pyglet/issues/531), but the workaround here should be fine.

@JustinTFleming can you test it with latest pyglet (1.5.21) and pyglet-ffmpeg?

FWIW @drammock for me when I play the video it plays way too fast on Linux -- it should take ~6 sec but it takes ~1. But this seems to be the case with newer Pyglet even before these PRs. Do you want to take a look? IIRC you worked on the timing stuff originally...?