### PR TITLE
Doc updates addressing #431

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.orig
 .vscode
 doc/generated
+.DS_Store
 
 # C extensions
 *.so

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -53,7 +53,7 @@ To get started quickly, this should suffice for conda users on most systems:
 
 .. code-block:: console
 
-    $ conda create -n expy mne pyglet -c conda-forge
+    $ conda create -n expy mne "pyglet<1.6" -c conda-forge
     $ conda activate expy
     $ pip install pyparallel rtmixer
     $ pip install git+https://github.com/labsn/expyfun
@@ -66,28 +66,34 @@ do this instead:
 
     $ conda create -n expy python=3 numpy scipy matplotlib pandas h5py joblib pillow
     $ conda activate expy
-    $ pip install mne pyglet pyparallel rtmixer
+    $ pip install mne "pyglet<1.6" pyparallel rtmixer
     $ pip install git+https://github.com/labsn/expyfun
 
 If you prefer using pip for everything, here are the minimum requirements:
 
 .. code-block:: console
 
-    $ pip install mne matplotlib pyglet pillow
+    $ pip install mne matplotlib "pyglet<1.6" pillow
     $ pip install git+https://github.com/labsn/expyfun
 
 and this does a full pip install of all required and optional dependencies:
 
 .. code-block:: console
 
-    $ pip install mne matplotlib pyglet pillow rtmixer pyparallel pandas joblib h5py TDTPy
+    $ pip install mne matplotlib "pyglet<1.6" pillow
+    $ pip install rtmixer pyparallel pandas joblib h5py TDTPy
     $ pip install git+https://github.com/labsn/expyfun
+
+Note that the pyglet package for the recommended installs is constrained to version 1.5, as this
+will be the last version compatible with legacy OpenGL (see pypi.org/project/pyglet/). If
+you prefer to download pyglet via its github repository, please use the pyglet-1.5-maintenance
+branch.
 
 
 Expyfun
 ^^^^^^^
 The recommended way to install expyfun on
-development machines is to ``git clone`` the reposity then do:
+development machines is to ``git clone`` the repository then do:
 
 .. code-block:: console
 

--- a/environment_test.yml
+++ b/environment_test.yml
@@ -12,7 +12,7 @@ dependencies:
 - pillow
 - joblib
 - pip:
-  - pyglet
+  - pyglet<1.6
   - codecov
   - pytest-sugar
   - numpydoc


### PR DESCRIPTION
Mainly this PR adds recommendations in _getting\_started.rst_ to install a version of pyglet that works with the current expyfun codebase. I was unable to create a browser-friendly version of the document (i.e. via the `make` command), so I'm uncertain if the formatting is correct.  Also, for the current version of the document, as rendered in my brower, I see text like ":func:\`expyfun.get_config_path\`", which I think are broken links.  I'd be happy to make fixes with some guidance.

I also made minor additions to the _requirements\_test.yml_ and _.gitignore_ files.

