### PR TITLE
MAINT: Dont use continue-on-error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,12 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   job:
     name: ${{ matrix.os }} ${{ matrix.kind }}
-    continue-on-error: true
     runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -el {0}
     strategy:
+      fail-fast: false
       matrix:
         include:
           # 24.04 works except for the video test, even though it works locally on 24.10
@@ -104,4 +104,4 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-        if: always()
+        if: success() || failure()


### PR DESCRIPTION
`continue-on-error: true` can lead to "successful" builds that had a failing step when `if: always()` is used, so just avoid it. Achieve the desired effect of not killing other *jobs* early with `fail-fast: false` instead.