### PR TITLE
Add option to set noise array or noise length

### DIFF
--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -80,6 +80,10 @@ class ExperimentController:
         The desired dB SPL at which to play the stimuli.
     noise_db : float
         The desired dB SPL at which to play the dichotic noise.
+    noise_dur : float
+        The minimum duration of the noise in seconds. It will be rounded up so
+        that the length of the noise at stim_fs is a power of 2 (required
+        for the ringbuffer). Default is 15 seconds.
     noise_array : ndarray | None
         An array containing the noise to be presented. Must have a length that
         is a power of 2, and generated with a reference RMS amplitude of 1 for
@@ -173,6 +177,7 @@ class ExperimentController:
         stim_fs=24414,
         stim_db=65,
         noise_db=45,
+        noise_dur=15,
         noise_array=None,
         check_noise_rms=True,
         output_dir="data",
@@ -198,6 +203,7 @@ class ExperimentController:
         self._stim_rms = stim_rms
         self._stim_db = stim_db
         self._noise_db = noise_db
+        self._noise_dur = noise_dur
         self._noise_array = noise_array
         self._check_noise_rms = check_noise_rms
         self._stim_scaler = None
@@ -447,6 +453,21 @@ class ExperimentController:
                     )
                 logger.warning(msg)
 
+            # set noise_dur to 15 seconds (default) if it's set to None
+            if self._noise_dur is None:
+                self._noise_dur = 15
+            # make sure noise_dur is a number
+            if not isinstance(self._noise_dur, (float, int)):
+                raise TypeError(
+                    f"noise_dur must be a positive number, got "
+                    f"{self._noise_dur}"
+                    )
+            # make sure noise_dur is positive
+            if self._noise_dur <= 0:
+                raise ValueError(
+                    f"noise_dur must be a positive number, got "
+                    f"{self._noise_dur}"
+                    )
             # check the check_noise_rms input and validate the noise_array
             if self._check_noise_rms is None:  # default to True when None
                 self._check_noise_rms = True

--- a/expyfun/_sound_controllers/_sound_controller.py
+++ b/expyfun/_sound_controllers/_sound_controller.py
@@ -170,8 +170,8 @@ class SoundCardController:
 
         if ec._noise_array is None:
             # Need to generate at RMS=1 to match TDT circuit, and use a power
-            # of 2 length for the RingBuffer (here make it >= 15 sec)
-            n_samples = 2 ** int(np.ceil(np.log2(self.fs * 15.0)))
+            # of 2 length for the RingBuffer (duration is passed from ec)
+            n_samples = 2 ** int(np.ceil(np.log2(self.fs * ec._noise_dur)))
             noise = np.random.normal(0, 1.0, (self._n_channels, n_samples))
 
             # Low-pass if necessary

--- a/expyfun/_version.py
+++ b/expyfun/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0.dev0"
+__version__ = '2.0.0.dev0'

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -803,3 +803,46 @@ def test_sound_card_params():
     for key in _SOUND_CARD_KEYS:
         if key != "TYPE":
             assert key in known_config_types, key
+
+
+def test_noise_array(hide_window):
+    noise_array = np.random.normal(0, 1, (2**10))
+    """Test that the noise_array can be set."""
+    # check for ValueError if noise_array length is not a power of 2
+    pytest.raises(
+        ValueError,
+        ExperimentController,
+        *std_args,
+        noise_array=noise_array[:1000],
+        **std_kwargs,
+        )
+    # check that the RMS of noise_array must be close to 1
+    pytest.raises(
+        ValueError,
+        ExperimentController,
+        *std_args,
+        noise_array=noise_array*0.01,
+        **std_kwargs,
+        )
+    pytest.raises(
+        ValueError,
+        ExperimentController,
+        *std_args,
+        noise_array=noise_array*3,
+        **std_kwargs,
+        )
+    # no errors if len(noise_array) is a power of 2 and RMS==1
+    with ExperimentController(
+        *std_args, noise_array=noise_array, **std_kwargs
+    ) as ec:
+        pass
+    # check that noise_array can have different RMS if check_noise_rms==False
+    with ExperimentController(
+        *std_args, noise_array=noise_array*5, check_noise_rms=False,
+        **std_kwargs
+    ) as ec:
+        pass
+    with ExperimentController(
+            *std_args, noise_array=None, **std_kwargs
+            ) as ec:
+        pass

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -805,7 +805,27 @@ def test_sound_card_params():
             assert key in known_config_types, key
 
 
-def test_noise_array(hide_window):
+def test_noise(hide_window):
+    """Test that the noise duration can be specified."""
+    pytest.raises(  # Error if a string is input
+        TypeError,
+        ExperimentController,
+        *std_args,
+        noise_dur='foo',
+        **std_kwargs,
+        )
+    pytest.raises(  # error if a negative number is input
+        ValueError,
+        ExperimentController,
+        *std_args,
+        noise_dur=-5,
+        **std_kwargs,
+        )
+    with ExperimentController(  # no error when noise_dur is a positive number
+            *std_args, noise_dur=10.2, **std_kwargs
+            ) as ec:
+        ec.start_noise()
+        ec.stop_noise()
     noise_array = np.random.normal(0, 1, (2**10))
     """Test that the noise_array can be set."""
     # check for ValueError if noise_array length is not a power of 2
@@ -835,14 +855,17 @@ def test_noise_array(hide_window):
     with ExperimentController(
         *std_args, noise_array=noise_array, **std_kwargs
     ) as ec:
-        pass
+        ec.start_noise()
+        ec.stop_noise()
     # check that noise_array can have different RMS if check_noise_rms==False
     with ExperimentController(
         *std_args, noise_array=noise_array*5, check_noise_rms=False,
         **std_kwargs
     ) as ec:
-        pass
+        ec.start_noise()
+        ec.stop_noise()
     with ExperimentController(
             *std_args, noise_array=None, **std_kwargs
             ) as ec:
-        pass
+        ec.start_noise()
+        ec.stop_noise()

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -829,28 +829,26 @@ def test_noise(hide_window):
     noise_array = np.random.normal(0, 1, (2**10))
     """Test that the noise_array can be set."""
     # check for ValueError if noise_array length is not a power of 2
-    pytest.raises(
-        ValueError,
-        ExperimentController,
-        *std_args,
-        noise_array=noise_array[:1000],
-        **std_kwargs,
-        )
+    with ExperimentController(
+            *std_args, noise_array=noise_array[:1000], **std_kwargs
+            ) as ec:
+        with pytest.raises(ValueError):
+            ec.start_noise()
+        ec.stop_noise()
     # check that the RMS of noise_array must be close to 1
-    pytest.raises(
-        ValueError,
-        ExperimentController,
-        *std_args,
-        noise_array=noise_array*0.01,
-        **std_kwargs,
-        )
-    pytest.raises(
-        ValueError,
-        ExperimentController,
-        *std_args,
-        noise_array=noise_array*3,
-        **std_kwargs,
-        )
+    with ExperimentController(
+            *std_args, noise_array=noise_array*0.01, **std_kwargs
+            ) as ec:
+        with pytest.raises(ValueError):
+            ec.start_noise()
+        ec.stop_noise()
+    with ExperimentController(
+            *std_args, noise_array=noise_array*3, **std_kwargs
+            ) as ec:
+        with pytest.raises(ValueError):
+            ec.start_noise()
+        ec.stop_noise()
+
     # no errors if len(noise_array) is a power of 2 and RMS==1
     with ExperimentController(
         *std_args, noise_array=noise_array, **std_kwargs


### PR DESCRIPTION
I'v updated `ExperimentContoller` and `SoundController` to add the options to either set a minimum duration for the AWGN that expyfun generates or input your own noise. It does some checks on the inputs and I've added some tests, although I don't write tests often, so I'm not sure if it's done properly. This would close #418 and #521 if merged. Let me know if you think there should be any changes.
