### PR TITLE
allow playing audio stream from videos

### DIFF
--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -971,7 +971,7 @@ class ExperimentController:
         return np.array(self._monitor["SCREEN_SIZE_PIX"])
 
     # ############################### VIDEO METHODS ###############################
-    def load_video(self, file_name, pos=(0, 0), units="norm", center=True):
+    def load_video(self, file_name, *, pos=(0, 0), units="norm", center=True):
         """Load a video.
 
         Parameters
@@ -990,7 +990,7 @@ class ExperimentController:
         except ImportError:  # < 1.4
             from pyglet.media import MediaFormatException
         try:
-            self.video = Video(self, file_name, pos, units)
+            self.video = Video(self, file_name, pos=pos, units=units)
         except MediaFormatException as exp:
             raise RuntimeError(
                 "Something is wrong; probably you tried to load a "

--- a/expyfun/_version.py
+++ b/expyfun/_version.py
@@ -1,1 +1,1 @@
-__version__ = '2.0.0.dev0'
+__version__ = "2.0.0.dev0"

--- a/expyfun/_version.py
+++ b/expyfun/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0.dev0"
+__version__ = '2.0.0.dev0'

--- a/expyfun/visual/_visual.py
+++ b/expyfun/visual/_visual.py
@@ -1277,7 +1277,7 @@ class Video:
             If True, add ``self.draw`` to ``ec.on_every_flip``.
         audio : bool
             Whether to play the audio stream. Only works if the
-            :class:`ExperimentController` was instantiated with
+            :class:`~expyfun.ExperimentController` was instantiated with
             ``audio_controller=dict(TYPE="sound_card", SOUND_CARD_BACKEND="pyglet")``,
             and will raise an error if that is not the case.
 

--- a/expyfun/visual/tests/test_visuals.py
+++ b/expyfun/visual/tests/test_visuals.py
@@ -126,3 +126,14 @@ def test_video(hide_window):
         ec.video.pause()
         ec.video.draw()
         ec.delete_video()
+    # test ec.video.play(audio=True)
+    with ExperimentController(
+        "test",
+        audio_controller=dict(TYPE="sound_card", SOUND_CARD_BACKEND="pyglet"),
+        **std_kwargs,
+    ) as ec:
+        ec.load_video(video_path)
+        ec.video.play(audio=True)
+        ec.wait_secs(0.1)
+        ec.video.pause()
+        ec.delete_video()

--- a/expyfun/visual/tests/test_visuals.py
+++ b/expyfun/visual/tests/test_visuals.py
@@ -105,7 +105,7 @@ def test_visuals(hide_window):
 
 
 @requires_video()
-def test_video(hide_window):
+def test_video(hide_window, monkeypatch):
     """Test EC video methods."""
     std_kwargs.update(dict(window_size=(640, 480)))
     video_path = fetch_data_file("video/example-video.mp4")
@@ -127,13 +127,16 @@ def test_video(hide_window):
         ec.video.draw()
         ec.delete_video()
     # test ec.video.play(audio=True)
-    with ExperimentController(
-        "test",
-        audio_controller=dict(TYPE="sound_card", SOUND_CARD_BACKEND="pyglet"),
-        **std_kwargs,
-    ) as ec:
-        ec.load_video(video_path)
-        ec.video.play(audio=True)
-        ec.wait_secs(0.1)
-        ec.video.pause()
-        ec.delete_video()
+    with monkeypatch.context() as m:
+        m.delenv("SOUND_CARD_NAME", raising=False)
+        m.delenv("SOUND_CARD_API", raising=False)
+        with ExperimentController(
+            "test",
+            audio_controller=dict(TYPE="sound_card", SOUND_CARD_BACKEND="pyglet"),
+            **std_kwargs,
+        ) as ec:
+            ec.load_video(video_path)
+            ec.video.play(audio=True)
+            ec.wait_secs(0.1)
+            ec.video.pause()
+            ec.delete_video()


### PR DESCRIPTION
- only works using sound card with Pyglet backend.
- API is `ec.video.play(audio=True)` (default False for backcompat).